### PR TITLE
Enabling cimplogger option using macro 'CIMP_LOGGER'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ project(wdmp-c)
 include(ExternalProject)
 
 add_definitions(-std=c99)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE -Werror -Wall")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GNU_SOURCE -Werror -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE -Werror -Wall -DCIMP_LOGGER")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GNU_SOURCE -Werror -Wall -DCIMP_LOGGER")
 
 set(INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/_install)
 set(PREFIX_DIR ${CMAKE_CURRENT_BINARY_DIR}/_prefix)
@@ -27,7 +27,9 @@ set(INCLUDE_DIR ${INSTALL_DIR}/include)
 set(LIBRARY_DIR ${INSTALL_DIR}/lib${LIB_SUFFIX})
 include_directories(${INCLUDE_DIR}
                     ${INCLUDE_DIR}/cjson
-                    ${CURL_INCLUDE_DIRS})
+                    ${CURL_INCLUDE_DIRS}
+					${INCLUDE_DIR}/cimplog)
+				
 include_directories (SYSTEM /usr/include)
 
 if (NOT BUILD_YOCTO)
@@ -41,6 +43,18 @@ ExternalProject_Add(cJSON
 )
 add_library(libcjson STATIC IMPORTED)
 add_dependencies(libcjson cjson)
+
+
+# cimplog external dependency
+ExternalProject_Add(cimplog
+    PREFIX ${PREFIX_DIR}/cimplog
+    GIT_REPOSITORY https://github.com/Comcast/cimplog.git
+    GIT_TAG "master"
+    CMAKE_ARGS += -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
+                  -DBUILD_TESTING=OFF
+)
+add_library(libcimplog STATIC IMPORTED)
+add_dependencies(libcimplog cimplog)
 
 endif ()
 

--- a/src/wdmp-c.c
+++ b/src/wdmp-c.c
@@ -57,7 +57,7 @@ void wdmp_parse_request(char * payload, req_struct **reqObj)
 	if(request != NULL)
 	{
 		command = cJSON_GetObjectItem(request, "command")->valuestring;
-		WdmpPrint("WDMP-C: command %s\n",(command == NULL) ? "NULL" : command);
+		WdmpPrint("command %s\n",(command == NULL) ? "NULL" : command);
 			
 		if( command != NULL) 
 		{
@@ -67,48 +67,48 @@ void wdmp_parse_request(char * payload, req_struct **reqObj)
 			
 			if ((strcmp(command, "GET") == 0)|| (strcmp(command, "GET_ATTRIBUTES") == 0))
 			{
-				WdmpInfo("WDMP-C: Request %s\n", out);
+				WdmpInfo("Request %s\n", out);
 				parse_get_request(request, reqObj);
 			
 			}		
 			else if ((strcmp(command, "SET") == 0))
 			{
-				WdmpInfo("WDMP-C: SET Request: %s\n", out);
+				WdmpInfo("SET Request: %s\n", out);
 				parse_set_request(request, reqObj);
 						
 			}
 			else if ((strcmp(command, "SET_ATTRIBUTES") == 0))
 			{
-				WdmpInfo("WDMP-C: SET ATTRIBUTES Request: %s\n", out);
+				WdmpInfo("SET ATTRIBUTES Request: %s\n", out);
 				parse_set_attr_request(request, reqObj);
 						
 			}			
 			else if (strcmp(command, "TEST_AND_SET") == 0)
 			{
-				WdmpInfo("WDMP-C: Test and Set Request: %s\n", out);
+				WdmpInfo("Test and Set Request: %s\n", out);
 				parse_test_and_set_request(request, reqObj);
 
 			}			
 			else if (strcmp(command, "REPLACE_ROWS") == 0)
 			{
-				WdmpInfo("WDMP-C: REPLACE_ROWS Request: %s\n", out);
+				WdmpInfo("REPLACE_ROWS Request: %s\n", out);
 				parse_replace_rows_request(request, reqObj);				
 			
 			}
 			else if (strcmp(command, "ADD_ROW") == 0)
 			{
-				WdmpInfo("WDMP-C: ADD_ROW Request: %s\n", out);
+				WdmpInfo("ADD_ROW Request: %s\n", out);
 				parse_add_row_request(request, reqObj);
 						
 			}			
 			else if (strcmp(command, "DELETE_ROW") == 0)
 			{
-				WdmpInfo("WDMP-C: DELETE_ROW Request: %s\n", out);
+				WdmpInfo("DELETE_ROW Request: %s\n", out);
 				parse_delete_row_request(request, reqObj);
 			}			
 			else
 			{
-				WdmpError("WDMP-C: Unknown Command \n");
+				WdmpError("Unknown Command \n");
 				wdmp_free_req_struct(*reqObj );
 				(*reqObj) = NULL;
 			}
@@ -116,7 +116,7 @@ void wdmp_parse_request(char * payload, req_struct **reqObj)
     	}
     	else
 	{
-		WdmpInfo("WDMP-C: Empty payload\n");
+		WdmpInfo("Empty payload\n");
 	}
  	
 }
@@ -128,7 +128,7 @@ void wdmp_form_response(res_struct *resObj, char **payload)
         if(resObj != NULL)
 	{
 	        response = cJSON_CreateObject();
-	        WdmpPrint("WDMP-C: resObj->reqType: %d\n",resObj->reqType);
+	        WdmpPrint("resObj->reqType: %d\n",resObj->reqType);
 	        
                 switch( resObj->reqType ) 
                 {
@@ -168,7 +168,7 @@ void wdmp_form_response(res_struct *resObj, char **payload)
                         
                         default:
                         {
-                                WdmpError("WDMP-C: Unknown request type\n");
+                                WdmpError("Unknown request type\n");
                                 wdmp_free_res_struct(resObj );
                                 resObj = NULL;
                                 cJSON_Delete(response);
@@ -180,7 +180,7 @@ void wdmp_form_response(res_struct *resObj, char **payload)
 	
         if(response != NULL)
 	{
-	        WdmpInfo("WDMP-C: Response Payload :%s\n",cJSON_PrintUnformatted(response));
+	        WdmpInfo("Response Payload :%s\n",cJSON_PrintUnformatted(response));
                 *payload = cJSON_PrintUnformatted(response);
 		cJSON_Delete(response);
 	}
@@ -255,7 +255,7 @@ void wdmp_free_req_struct( req_struct *reqObj )
                 break;
 
                 default:
-                WdmpError("WDMP-C: Unknown request type\n");
+                WdmpError("Unknown request type\n");
         }
         
         free(reqObj);

--- a/src/wdmp_internal.c
+++ b/src/wdmp_internal.c
@@ -55,16 +55,16 @@ void parse_get_request(cJSON *request, req_struct **reqObj)
 
 	char *param = NULL;
 	(*reqObj)->reqType = GET;
-	WdmpPrint("WDMP-C: (*reqObj)->reqType : %d\n",(*reqObj)->reqType);
+	WdmpPrint("(*reqObj)->reqType : %d\n",(*reqObj)->reqType);
 	paramArray = cJSON_GetObjectItem(request, "names");
 	paramCount = cJSON_GetArraySize(paramArray);
 	(*reqObj)->u.getReq->paramCnt = paramCount;
-	WdmpPrint("WDMP-C: (*reqObj)->u.getReq->paramCnt : %zu\n",(*reqObj)->u.getReq->paramCnt);
+	WdmpPrint("(*reqObj)->u.getReq->paramCnt : %zu\n",(*reqObj)->u.getReq->paramCnt);
 	
 	for (i = 0; i < paramCount; i++) 
 	{
 		(*reqObj)->u.getReq->paramNames[i] = cJSON_GetArrayItem(paramArray, i)->valuestring;
-		WdmpPrint("WDMP-C: (*reqObj)->u.getReq->paramNames[%zu] : %s\n",i,(*reqObj)->u.getReq->paramNames[i]);
+		WdmpPrint("(*reqObj)->u.getReq->paramNames[%zu] : %s\n",i,(*reqObj)->u.getReq->paramNames[i]);
 	}
 
 	if(cJSON_GetObjectItem(request, "attributes") != NULL) 
@@ -74,19 +74,19 @@ void parse_get_request(cJSON *request, req_struct **reqObj)
 			if(strncmp(cJSON_GetObjectItem(request, "attributes")->valuestring, "notify", 6) == 0)
 			{
 				(*reqObj)->reqType = GET_ATTRIBUTES;
-				WdmpPrint("WDMP-C: (*reqObj)->reqType : %d\n",(*reqObj)->reqType);
+				WdmpPrint("(*reqObj)->reqType : %d\n",(*reqObj)->reqType);
 				for (i = 0; i < paramCount; i++) 
 				{
 					param = (cJSON_GetArrayItem(paramArray, i)->valuestring);
-					WdmpPrint("WDMP-C: param : %s\n",param);
+					WdmpPrint("param : %s\n",param);
 					(*reqObj)->u.getReq->paramNames[i] = param;
-					WdmpPrint("WDMP-C: (*reqObj)->u.getReq->paramNames[%zu] : %s\n",i,(*reqObj)->u.getReq->paramNames[i]);			
+					WdmpPrint("(*reqObj)->u.getReq->paramNames[%zu] : %s\n",i,(*reqObj)->u.getReq->paramNames[i]);			
 				}
 			}
 		}
 		else
 		{	
-			WdmpError("WDMP-C: Empty notify received\n");
+			WdmpError("Empty notify received\n");
 			wdmp_free_req_struct(*reqObj );
 			(*reqObj) = NULL;
 		}
@@ -100,19 +100,19 @@ void parse_set_request(cJSON *request, req_struct **reqObj)
 	cJSON *reqParamObj = NULL,*paramArray = NULL;	
 	size_t paramCount, i;
 	
-	WdmpPrint("WDMP-C: parsing Set Request\n");
+	WdmpPrint("parsing Set Request\n");
 	
 	paramArray = cJSON_GetObjectItem(request, "parameters");
 	paramCount = cJSON_GetArraySize(paramArray);
 	
 	(*reqObj)->reqType = SET;
-	WdmpPrint("WDMP-C: (*reqObj)->reqType : %d\n",(*reqObj)->reqType);
+	WdmpPrint("(*reqObj)->reqType : %d\n",(*reqObj)->reqType);
 
 	(*reqObj)->u.setReq = (set_req_t *) malloc(sizeof(set_req_t));
 	memset((*reqObj)->u.setReq,0,(sizeof(set_req_t)));
 
 	(*reqObj)->u.setReq->paramCnt = paramCount;
-	WdmpPrint("WDMP-C: (*reqObj)->u.setReq->paramCnt : %zu\n",(*reqObj)->u.setReq->paramCnt);
+	WdmpPrint("(*reqObj)->u.setReq->paramCnt : %zu\n",(*reqObj)->u.setReq->paramCnt);
 	(*reqObj)->u.setReq->param = (param_t *) malloc(sizeof(param_t) * paramCount);
 	memset((*reqObj)->u.setReq->param,0,(sizeof(param_t) * paramCount));
 
@@ -120,29 +120,29 @@ void parse_set_request(cJSON *request, req_struct **reqObj)
 	{
 		reqParamObj = cJSON_GetArrayItem(paramArray, i);
 		(*reqObj)->u.setReq->param[i].name = cJSON_GetObjectItem(reqParamObj, "name")->valuestring;
-		WdmpPrint("WDMP-C: (*reqObj)->u.setReq->param[%zu].name : %s\n",i,(*reqObj)->u.setReq->param[i].name);
+		WdmpPrint("(*reqObj)->u.setReq->param[%zu].name : %s\n",i,(*reqObj)->u.setReq->param[i].name);
 		
 		if (cJSON_GetObjectItem(reqParamObj, "value") != NULL )
 		{
 			if(cJSON_GetObjectItem(reqParamObj, "value")->valuestring != NULL && strlen(cJSON_GetObjectItem(reqParamObj, "value")->valuestring) == 0)
 			{
-				WdmpError("WDMP-C: Parameter value is null\n");
+				WdmpError("Parameter value is null\n");
 			}
 			else if(cJSON_GetObjectItem(reqParamObj, "value")->valuestring == NULL)
 			{
-				WdmpError("WDMP-C: Parameter value field is not a string\n");
+				WdmpError("Parameter value field is not a string\n");
 			}
 			else
 			{
 				(*reqObj)->u.setReq->param[i].value = cJSON_GetObjectItem(reqParamObj, "value")->valuestring;
-				WdmpPrint("WDMP-C: (*reqObj)->u.setReq->param[%zu].value : %s\n",i,(*reqObj)->u.setReq->param[i].value);
+				WdmpPrint("(*reqObj)->u.setReq->param[%zu].value : %s\n",i,(*reqObj)->u.setReq->param[i].value);
 			}
 		}
 	
 		if (cJSON_GetObjectItem(reqParamObj, "dataType") != NULL)
 		{
 			(*reqObj)->u.setReq->param[i].type = cJSON_GetObjectItem(reqParamObj, "dataType")->valueint;
-			WdmpPrint("WDMP-C: (*reqObj)->u.setReq->param[%zu].type : %d\n",i,(*reqObj)->u.setReq->param[i].type);
+			WdmpPrint("(*reqObj)->u.setReq->param[%zu].type : %d\n",i,(*reqObj)->u.setReq->param[i].type);
 		}
 	}
 			
@@ -156,19 +156,19 @@ void parse_set_attr_request(cJSON *request, req_struct **reqObj)
 	int notification;
 	char notif[20] = "";
 	
-	WdmpPrint("WDMP-C: parsing Set attributes Request\n");
+	WdmpPrint("parsing Set attributes Request\n");
 	
 	paramArray = cJSON_GetObjectItem(request, "parameters");
 	paramCount = cJSON_GetArraySize(paramArray);
         
         (*reqObj)->reqType = SET_ATTRIBUTES;
-        WdmpPrint("WDMP-C: (*reqObj)->reqType : %d\n",(*reqObj)->reqType);
+        WdmpPrint("(*reqObj)->reqType : %d\n",(*reqObj)->reqType);
 	                
 	(*reqObj)->u.setReq = (set_req_t *) malloc(sizeof(set_req_t));
 	memset((*reqObj)->u.setReq,0,(sizeof(set_req_t)));
 
 	(*reqObj)->u.setReq->paramCnt = paramCount;
-	WdmpPrint("WDMP-C: (*reqObj)->u.setReq->paramCnt : %zu\n",(*reqObj)->u.setReq->paramCnt);
+	WdmpPrint("(*reqObj)->u.setReq->paramCnt : %zu\n",(*reqObj)->u.setReq->paramCnt);
 	(*reqObj)->u.setReq->param = (param_t *) malloc(sizeof(param_t) * paramCount);
 	memset((*reqObj)->u.setReq->param,0,(sizeof(param_t) * paramCount));
 
@@ -176,7 +176,7 @@ void parse_set_attr_request(cJSON *request, req_struct **reqObj)
 	{
 		reqParamObj = cJSON_GetArrayItem(paramArray, i);
 		(*reqObj)->u.setReq->param[i].name = cJSON_GetObjectItem(reqParamObj, "name")->valuestring;
-		WdmpPrint("WDMP-C: (*reqObj)->u.setReq->param[%zu].name : %s\n",i,(*reqObj)->u.setReq->param[i].name);
+		WdmpPrint("(*reqObj)->u.setReq->param[%zu].name : %s\n",i,(*reqObj)->u.setReq->param[i].name);
 		
 		if (cJSON_GetObjectItem(reqParamObj, "attributes") != NULL )
 		{
@@ -184,16 +184,16 @@ void parse_set_attr_request(cJSON *request, req_struct **reqObj)
 			if(cJSON_GetObjectItem(attributes, "notify") != NULL) 
 			{
 				notification = cJSON_GetObjectItem(attributes, "notify")->valueint;
-				WdmpPrint("WDMP-C: notification :%d\n",notification);
+				WdmpPrint("notification :%d\n",notification);
 				snprintf(notif, sizeof(notif), "%d", notification);
 				(*reqObj)->u.setReq->param[i].value = (char *) malloc(sizeof(char) * 20);
 				strcpy((*reqObj)->u.setReq->param[i].value, notif);
-				WdmpPrint("WDMP-C: (*reqObj)->u.setReq->param[%zu].value : %s\n",i,(*reqObj)->u.setReq->param[i].value);
+				WdmpPrint("(*reqObj)->u.setReq->param[%zu].value : %s\n",i,(*reqObj)->u.setReq->param[i].value);
 			}
 		}
 		
 		(*reqObj)->u.setReq->param[i].type = WDMP_INT;
-		WdmpPrint("WDMP-C: (*reqObj)->u.setReq->param[%zu].type : %d\n",i,(*reqObj)->u.setReq->param[i].type);
+		WdmpPrint("(*reqObj)->u.setReq->param[%zu].type : %d\n",i,(*reqObj)->u.setReq->param[i].type);
 	}
 			
 }
@@ -204,9 +204,9 @@ void parse_test_and_set_request(cJSON *request, req_struct **reqObj)
 	cJSON *reqParamObj = NULL, *paramArray = NULL;	
 	size_t paramCount, i;
 	
-	WdmpPrint("WDMP-C: parsing Test and Set Request\n");
+	WdmpPrint("parsing Test and Set Request\n");
 	(*reqObj)->reqType = TEST_AND_SET;
-	WdmpPrint("WDMP-C: (*reqObj)->reqType : %d\n",(*reqObj)->reqType);
+	WdmpPrint("(*reqObj)->reqType : %d\n",(*reqObj)->reqType);
 	
 	(*reqObj)->u.testSetReq = (test_set_req_t *) malloc(sizeof(test_set_req_t));
 	memset((*reqObj)->u.testSetReq,0,(sizeof(test_set_req_t)));
@@ -214,17 +214,17 @@ void parse_test_and_set_request(cJSON *request, req_struct **reqObj)
 	if(cJSON_GetObjectItem(request, "old-cid") != NULL)
 	{
 	        (*reqObj)->u.testSetReq->oldCid = cJSON_GetObjectItem(request, "old-cid")->valuestring;
-	        WdmpPrint("WDMP-C: (*reqObj)->u.testSetReq->oldCid : %s\n",(*reqObj)->u.testSetReq->oldCid);
+	        WdmpPrint("(*reqObj)->u.testSetReq->oldCid : %s\n",(*reqObj)->u.testSetReq->oldCid);
 	}
 	if(cJSON_GetObjectItem(request, "new-cid") != NULL)
 	{
 	        (*reqObj)->u.testSetReq->newCid = cJSON_GetObjectItem(request, "new-cid")->valuestring;
-	        WdmpPrint("WDMP-C: (*reqObj)->u.testSetReq->newCid : %s\n",(*reqObj)->u.testSetReq->newCid);
+	        WdmpPrint("(*reqObj)->u.testSetReq->newCid : %s\n",(*reqObj)->u.testSetReq->newCid);
 	}
 	if(cJSON_GetObjectItem(request, "sync-cmc") != NULL)
 	{
 		(*reqObj)->u.testSetReq->syncCmc = cJSON_GetObjectItem(request, "sync-cmc")->valuestring;
-		WdmpPrint("WDMP-C: (*reqObj)->u.testSetReq->syncCmc : %s\n",(*reqObj)->u.testSetReq->syncCmc);
+		WdmpPrint("(*reqObj)->u.testSetReq->syncCmc : %s\n",(*reqObj)->u.testSetReq->syncCmc);
 	}
 		
 	if (cJSON_GetObjectItem(request, "parameters") != NULL) // No Parameters
@@ -233,7 +233,7 @@ void parse_test_and_set_request(cJSON *request, req_struct **reqObj)
 		paramCount = cJSON_GetArraySize(paramArray);
 	
 		(*reqObj)->u.testSetReq->paramCnt = paramCount;
-		WdmpPrint("WDMP-C: (*reqObj)->u.testSetReq->paramCnt : %zu\n",(*reqObj)->u.testSetReq->paramCnt);
+		WdmpPrint("(*reqObj)->u.testSetReq->paramCnt : %zu\n",(*reqObj)->u.testSetReq->paramCnt);
 	
 		(*reqObj)->u.testSetReq->param = (param_t *) malloc(sizeof(param_t) * paramCount);
 	        memset((*reqObj)->u.testSetReq->param,0,(sizeof(param_t) * paramCount));
@@ -242,19 +242,19 @@ void parse_test_and_set_request(cJSON *request, req_struct **reqObj)
 		{
 			reqParamObj = cJSON_GetArrayItem(paramArray, i);
 			(*reqObj)->u.testSetReq->param[i].name = cJSON_GetObjectItem(reqParamObj, "name")->valuestring;
-			WdmpPrint("WDMP-C: (*reqObj)->u.testSetReq->param[%zu].name : %s\n",i,(*reqObj)->u.testSetReq->param[i].name);
+			WdmpPrint("(*reqObj)->u.testSetReq->param[%zu].name : %s\n",i,(*reqObj)->u.testSetReq->param[i].name);
 		
 			if (cJSON_GetObjectItem(reqParamObj, "value") != NULL)
 			{
 				(*reqObj)->u.testSetReq->param[i].value = cJSON_GetObjectItem(reqParamObj, "value")->valuestring;
-				WdmpPrint("WDMP-C: (*reqObj)->u.testSetReq->param[%zu].value : %s\n",i,(*reqObj)->u.testSetReq->param[i].value);
+				WdmpPrint("(*reqObj)->u.testSetReq->param[%zu].value : %s\n",i,(*reqObj)->u.testSetReq->param[i].value);
 			
 			}
 		
 			if (cJSON_GetObjectItem(reqParamObj, "dataType") != NULL)
 			{
 				(*reqObj)->u.testSetReq->param[i].type = cJSON_GetObjectItem(reqParamObj, "dataType")->valueint;
-				WdmpPrint("WDMP-C: (*reqObj)->u.testSetReq->param[%zu].type : %d\n",i,(*reqObj)->u.testSetReq->param[i].type);
+				WdmpPrint("(*reqObj)->u.testSetReq->param[%zu].type : %d\n",i,(*reqObj)->u.testSetReq->param[i].type);
 			}
 		}
 	}
@@ -266,19 +266,19 @@ void parse_replace_rows_request(cJSON *request, req_struct **reqObj)
 	cJSON *paramArray = NULL, *subitem = NULL;	
 	size_t paramCount,rowCnt, i, j;
 	
-	WdmpPrint("WDMP-C: parsing Replace Rows Request\n");
+	WdmpPrint("parsing Replace Rows Request\n");
 	(*reqObj)->reqType = REPLACE_ROWS;
-	WdmpPrint("WDMP-C: (*reqObj)->reqType : %d\n",(*reqObj)->reqType);
+	WdmpPrint("(*reqObj)->reqType : %d\n",(*reqObj)->reqType);
 	
 	paramArray = cJSON_GetObjectItem(request, "rows");
 	rowCnt = cJSON_GetArraySize(paramArray);
-	WdmpPrint("WDMP-C: rowCnt : %zu\n",rowCnt);
+	WdmpPrint("rowCnt : %zu\n",rowCnt);
 	
 	(*reqObj)->u.tableReq = (table_req_t *) malloc(sizeof(table_req_t));
 	memset((*reqObj)->u.tableReq,0,(sizeof(table_req_t)));
 	
 	(*reqObj)->u.tableReq->rowCnt = rowCnt;
-	WdmpPrint("WDMP-C: (*reqObj)->u.tableReq->rowCnt : %zu\n",(*reqObj)->u.tableReq->rowCnt);
+	WdmpPrint("(*reqObj)->u.tableReq->rowCnt : %zu\n",(*reqObj)->u.tableReq->rowCnt);
 	(*reqObj)->u.tableReq->objectName = cJSON_GetObjectItem(request,"table")->valuestring;
 	(*reqObj)->u.tableReq->rows = (TableData *) malloc(sizeof(TableData) * rowCnt);
 	memset((*reqObj)->u.tableReq->rows,0,(sizeof(TableData) * rowCnt));
@@ -287,19 +287,19 @@ void parse_replace_rows_request(cJSON *request, req_struct **reqObj)
         {
                 subitem = cJSON_GetArrayItem(paramArray, i);
 	        paramCount = cJSON_GetArraySize(subitem);
-	 	WdmpPrint("WDMP-C: paramCount: %zu\n",paramCount);
+	 	WdmpPrint("paramCount: %zu\n",paramCount);
 	        (*reqObj)->u.tableReq->rows[i].paramCnt = paramCount;
-	        WdmpPrint("WDMP-C: (*reqObj)->u.tableReq->rows[%zu].paramCnt : %zu\n",i,(*reqObj)->u.tableReq->rows[i].paramCnt);
+	        WdmpPrint("(*reqObj)->u.tableReq->rows[%zu].paramCnt : %zu\n",i,(*reqObj)->u.tableReq->rows[i].paramCnt);
 	        
 	        (*reqObj)->u.tableReq->rows[i].names = (char **) malloc(sizeof(char *) * paramCount);
 	        (*reqObj)->u.tableReq->rows[i].values = (char **) malloc(sizeof(char *) * paramCount);
 	        for( j = 0 ; j < paramCount ; j++)
 	        {
 		        (*reqObj)->u.tableReq->rows[i].names[j] = cJSON_GetArrayItem(subitem, j)->string;
-		        WdmpPrint("WDMP-C: (*reqObj)->u.tableReq->rows[%zu].names[%zu] : %s\n",i,j,(*reqObj)->u.tableReq->rows[i].names[j]);		
+		        WdmpPrint("(*reqObj)->u.tableReq->rows[%zu].names[%zu] : %s\n",i,j,(*reqObj)->u.tableReq->rows[i].names[j]);		
 		        		
 		        (*reqObj)->u.tableReq->rows[i].values[j] = cJSON_GetArrayItem(subitem, j)->valuestring;
-		        WdmpPrint("WDMP-C: (*reqObj)->u.tableReq->rows[%zu].values[%zu] : %s\n",i,j,(*reqObj)->u.tableReq->rows[i].values[j]);	
+		        WdmpPrint("(*reqObj)->u.tableReq->rows[%zu].values[%zu] : %s\n",i,j,(*reqObj)->u.tableReq->rows[i].values[j]);	
 		        	
 	        }
 	}
@@ -311,19 +311,19 @@ void parse_add_row_request(cJSON *request, req_struct **reqObj)
 	cJSON *paramArray = NULL;	
 	size_t paramCount, i;
 	
-	WdmpPrint("WDMP-C: parsing Add Row Request\n");
+	WdmpPrint("parsing Add Row Request\n");
 	(*reqObj)->reqType = ADD_ROWS;
-	WdmpPrint("WDMP-C: (*reqObj)->reqType : %d\n",(*reqObj)->reqType);
+	WdmpPrint("(*reqObj)->reqType : %d\n",(*reqObj)->reqType);
 	
 	paramArray = cJSON_GetObjectItem(request, "row");
 	paramCount = cJSON_GetArraySize(paramArray);
-	WdmpPrint("WDMP-C: paramCount : %zu\n",paramCount);
+	WdmpPrint("paramCount : %zu\n",paramCount);
 	
 	(*reqObj)->u.tableReq = (table_req_t *) malloc(sizeof(table_req_t));
 	memset((*reqObj)->u.tableReq,0,(sizeof(table_req_t)));
 	
 	(*reqObj)->u.tableReq->rowCnt = 1;
-	WdmpPrint("WDMP-C: (*reqObj)->u.tableReq->rowCnt : %zu\n",(*reqObj)->u.tableReq->rowCnt);
+	WdmpPrint("(*reqObj)->u.tableReq->rowCnt : %zu\n",(*reqObj)->u.tableReq->rowCnt);
 	(*reqObj)->u.tableReq->objectName = cJSON_GetObjectItem(request,"table")->valuestring;
 	(*reqObj)->u.tableReq->rows = (TableData *) malloc(sizeof(TableData));
 	memset((*reqObj)->u.tableReq->rows,0,(sizeof(TableData)));
@@ -331,14 +331,14 @@ void parse_add_row_request(cJSON *request, req_struct **reqObj)
 	(*reqObj)->u.tableReq->rows->names = (char **) malloc(sizeof(char *) * paramCount);
         (*reqObj)->u.tableReq->rows->values = (char **) malloc(sizeof(char *) * paramCount);
         (*reqObj)->u.tableReq->rows->paramCnt = paramCount;
-        WdmpPrint("WDMP-C: (*reqObj)->u.tableReq->rows->paramCnt : %zu\n",(*reqObj)->u.tableReq->rows->paramCnt);
+        WdmpPrint("(*reqObj)->u.tableReq->rows->paramCnt : %zu\n",(*reqObj)->u.tableReq->rows->paramCnt);
         
         for ( i = 0 ; i < paramCount ; i++)
         {
 	        (*reqObj)->u.tableReq->rows->names[i] = cJSON_GetArrayItem(paramArray, i)->string;
-	         WdmpPrint("WDMP-C: (*reqObj)->u.tableReq->rows->names[%zu] : %s\n",i,(*reqObj)->u.tableReq->rows->names[i]);				
+	         WdmpPrint("(*reqObj)->u.tableReq->rows->names[%zu] : %s\n",i,(*reqObj)->u.tableReq->rows->names[i]);				
 	        (*reqObj)->u.tableReq->rows->values[i] = cJSON_GetArrayItem(paramArray, i)->valuestring;
-	        WdmpPrint("WDMP-C: (*reqObj)->u.tableReq->rows->values[%zu] : %s\n",i,(*reqObj)->u.tableReq->rows->values[i]);		
+	        WdmpPrint("(*reqObj)->u.tableReq->rows->values[%zu] : %s\n",i,(*reqObj)->u.tableReq->rows->values[i]);		
 	        	
 	}
 }
@@ -346,9 +346,9 @@ void parse_add_row_request(cJSON *request, req_struct **reqObj)
 void parse_delete_row_request(cJSON *request, req_struct **reqObj)
 {
 	
-	WdmpPrint("WDMP-C: parsing Delete Row Request\n");
+	WdmpPrint("parsing Delete Row Request\n");
 	(*reqObj)->reqType = DELETE_ROW;
-	WdmpPrint("WDMP-C: (*reqObj)->reqType : %d\n",(*reqObj)->reqType);
+	WdmpPrint("(*reqObj)->reqType : %d\n",(*reqObj)->reqType);
 	
 	(*reqObj)->u.tableReq = (table_req_t *) malloc(sizeof(table_req_t));
 	memset((*reqObj)->u.tableReq,0,(sizeof(table_req_t)));
@@ -362,36 +362,36 @@ void wdmp_form_get_response(res_struct *resObj, cJSON *response)
         char *result = NULL;
         WDMP_RESPONSE_STATUS_CODE statusCode = WDMP_STATUS_GENERAL_FALURE;
         
-        WdmpPrint("WDMP-C: resObj->paramCnt : %zu\n",resObj->paramCnt);
+        WdmpPrint("resObj->paramCnt : %zu\n",resObj->paramCnt);
         paramCount = resObj->paramCnt;
-        WdmpPrint("WDMP-C: paramCount : %zu\n",paramCount);
+        WdmpPrint("paramCount : %zu\n",paramCount);
         result = (char *) malloc(sizeof(char) * MAX_PARAMETER_LEN);
                 
         getStatusCode(&statusCode, paramCount, resObj->retStatus);
-        WdmpPrint("WDMP-C: statusCode : %d\n",statusCode);
+        WdmpPrint("statusCode : %d\n",statusCode);
         if(statusCode == WDMP_STATUS_SUCCESS)
         {
                 cJSON_AddItemToObject(response, "parameters", parameters =cJSON_CreateArray());
-                WdmpPrint("WDMP-C: resObj->u.getRes->paramCnt : %zu\n",resObj->u.getRes->paramCnt);
+                WdmpPrint("resObj->u.getRes->paramCnt : %zu\n",resObj->u.getRes->paramCnt);
                 for (i = 0; i < paramCount; i++) 
                 {
                         cJSON_AddItemToArray(parameters, resParamObj = cJSON_CreateObject());
-                        WdmpPrint("WDMP-C: resObj->u.getRes->retParamCnt[%zu] : %zu\n",i,resObj->u.getRes->retParamCnt[i]);
+                        WdmpPrint("resObj->u.getRes->retParamCnt[%zu] : %zu\n",i,resObj->u.getRes->retParamCnt[i]);
                         if(resObj->u.getRes->retParamCnt[i] >= 1)
                         {
 	                        if(resObj->u.getRes->retParamCnt[i] > 1)
 	                        {
-	                                WdmpPrint("WDMP-C: resObj->u.getRes->paramNames[%zu] : %s\n",i,resObj->u.getRes->paramNames[i]);
+	                                WdmpPrint("resObj->u.getRes->paramNames[%zu] : %s\n",i,resObj->u.getRes->paramNames[i]);
                                         cJSON_AddStringToObject(resParamObj, "name", resObj->u.getRes->paramNames[i]);
                                         cJSON_AddItemToObject(resParamObj, "value",value = cJSON_CreateArray());
                                         for (j = 0; j < resObj->u.getRes->retParamCnt[i]; j++) 
                                         {
                                                 cJSON_AddItemToArray(value, valueObj = cJSON_CreateObject());
-                                                WdmpPrint("WDMP-C: resObj->u.getRes->params[%zu][%zu].name :%s\n",i,j,resObj->u.getRes->params[i][j].name);
+                                                WdmpPrint("resObj->u.getRes->params[%zu][%zu].name :%s\n",i,j,resObj->u.getRes->params[i][j].name);
                                                 cJSON_AddStringToObject(valueObj, "name", resObj->u.getRes->params[i][j].name);
-	                                        WdmpPrint("WDMP-C: resObj->u.getRes->params[%zu][%zu].value :%s\n",i,j,resObj->u.getRes->params[i][j].value);
+	                                        WdmpPrint("resObj->u.getRes->params[%zu][%zu].value :%s\n",i,j,resObj->u.getRes->params[i][j].value);
 	                                        cJSON_AddStringToObject(valueObj, "value",resObj->u.getRes->params[i][j].value);
-	                                        WdmpPrint("WDMP-C: resObj->u.getRes->params[%zu][%zu].type :%d\n",i,j,resObj->u.getRes->params[i][j].type);
+	                                        WdmpPrint("resObj->u.getRes->params[%zu][%zu].type :%d\n",i,j,resObj->u.getRes->params[i][j].type);
 	                                        cJSON_AddNumberToObject(valueObj, "dataType",resObj->u.getRes->params[i][j].type);
                                         }
                                         cJSON_AddNumberToObject(resParamObj, "dataType",WDMP_NONE);
@@ -401,11 +401,11 @@ void wdmp_form_get_response(res_struct *resObj, cJSON *response)
 	                        }
 	                        else
 	                        {
-	                                WdmpPrint("WDMP-C: resObj->u.getRes->params[%zu][0].name :%s\n",i,resObj->u.getRes->params[i][0].name);
+	                                WdmpPrint("resObj->u.getRes->params[%zu][0].name :%s\n",i,resObj->u.getRes->params[i][0].name);
                                         cJSON_AddStringToObject(resParamObj, "name", resObj->u.getRes->params[i][0].name);
-	                                WdmpPrint("WDMP-C: resObj->u.getRes->params[%zu][0].value :%s\n",i,resObj->u.getRes->params[i][0].value);
+	                                WdmpPrint("resObj->u.getRes->params[%zu][0].value :%s\n",i,resObj->u.getRes->params[i][0].value);
 	                                cJSON_AddStringToObject(resParamObj, "value",resObj->u.getRes->params[i][0].value);
-	                                WdmpPrint("WDMP-C: resObj->u.getRes->params[%zu][0].type :%d\n",i,resObj->u.getRes->params[i][0].type);
+	                                WdmpPrint("resObj->u.getRes->params[%zu][0].type :%d\n",i,resObj->u.getRes->params[i][0].type);
 	                                cJSON_AddNumberToObject(resParamObj, "dataType",resObj->u.getRes->params[i][0].type);
 	                                cJSON_AddNumberToObject(resParamObj, "parameterCount", resObj->u.getRes->retParamCnt[i]);
 	                                mapWdmpStatusToStatusMessage(resObj->retStatus[i], result);
@@ -414,7 +414,7 @@ void wdmp_form_get_response(res_struct *resObj, cJSON *response)
                         }
                         else
                         {
-                                WdmpPrint("WDMP-C: resObj->u.getRes->paramNames[%zu] : %s\n",i,resObj->u.getRes->paramNames[i]);
+                                WdmpPrint("resObj->u.getRes->paramNames[%zu] : %s\n",i,resObj->u.getRes->paramNames[i]);
                                 cJSON_AddStringToObject(resParamObj, "name", resObj->u.getRes->paramNames[i]);
                                 cJSON_AddStringToObject(resParamObj, "value","EMPTY");
                                 cJSON_AddNumberToObject(resParamObj, "parameterCount", resObj->u.getRes->retParamCnt[i]);
@@ -443,9 +443,9 @@ void wdmp_form_get_response(res_struct *resObj, cJSON *response)
         int notification;
         WDMP_RESPONSE_STATUS_CODE statusCode = WDMP_STATUS_GENERAL_FALURE;
         
-        WdmpPrint("WDMP-C: resObj->paramCnt : %zu\n",resObj->paramCnt);
+        WdmpPrint("resObj->paramCnt : %zu\n",resObj->paramCnt);
         paramCount = resObj->paramCnt;
-        WdmpPrint("WDMP-C: paramCount : %zu\n",paramCount);
+        WdmpPrint("paramCount : %zu\n",paramCount);
                 
         getStatusCode(&statusCode, paramCount, resObj->retStatus);
         result = (char *) malloc(sizeof(char) * MAX_PARAMETER_LEN);
@@ -455,14 +455,14 @@ void wdmp_form_get_response(res_struct *resObj, cJSON *response)
                 for (i = 0; i < paramCount; i++) 
                 {
                         cJSON_AddItemToArray(parameters, resParamObj = cJSON_CreateObject());
-                        WdmpPrint("WDMP-C: resObj->u.paramRes->params[%zu].name :%s\n",i,resObj->u.paramRes->params[i].name);
+                        WdmpPrint("resObj->u.paramRes->params[%zu].name :%s\n",i,resObj->u.paramRes->params[i].name);
                         cJSON_AddStringToObject(resParamObj, "name", resObj->u.paramRes->params[i].name);
                         cJSON_AddItemToObject(resParamObj, "attributes",attributes = cJSON_CreateObject());
-                        WdmpPrint("WDMP-C: resObj->u.paramRes->params[%zu].value :%s\n",i,resObj->u.paramRes->params[i].value);
+                        WdmpPrint("resObj->u.paramRes->params[%zu].value :%s\n",i,resObj->u.paramRes->params[i].value);
 	                notification = atoi(resObj->u.paramRes->params[i].value);
-	                WdmpPrint("WDMP-C: notification : %d\n", notification);
+	                WdmpPrint("notification : %d\n", notification);
 	                cJSON_AddNumberToObject(attributes, "notify", notification);
-	                WdmpPrint("WDMP-C: resObj->retStatus[i] :%d\n",resObj->retStatus[i]);
+	                WdmpPrint("resObj->retStatus[i] :%d\n",resObj->retStatus[i]);
                         mapWdmpStatusToStatusMessage(resObj->retStatus[i], result);
                         cJSON_AddStringToObject(resParamObj, "message", result);
                 }
@@ -478,7 +478,7 @@ void wdmp_form_get_response(res_struct *resObj, cJSON *response)
                 free(result); 
         }
         
-        WdmpPrint("WDMP-C: statusCode : %d\n",statusCode);
+        WdmpPrint("statusCode : %d\n",statusCode);
         cJSON_AddNumberToObject(response, "statusCode", statusCode);
         
 }
@@ -490,11 +490,11 @@ void wdmp_form_get_response(res_struct *resObj, cJSON *response)
         char *result = NULL;
         WDMP_RESPONSE_STATUS_CODE statusCode = WDMP_STATUS_GENERAL_FALURE;
         
-        WdmpPrint("WDMP-C: resObj->paramCnt : %zu\n",resObj->paramCnt);
+        WdmpPrint("resObj->paramCnt : %zu\n",resObj->paramCnt);
         paramCount = resObj->paramCnt;
-        WdmpPrint("WDMP-C: paramCount : %zu\n",paramCount);  
+        WdmpPrint("paramCount : %zu\n",paramCount);  
         
-        WdmpPrint("WDMP-C: resObj->retStatus : %d\n",resObj->retStatus[0]);
+        WdmpPrint("resObj->retStatus : %d\n",resObj->retStatus[0]);
         getStatusCode(&statusCode, paramCount, resObj->retStatus);
         
         result = (char *) malloc(sizeof(char) * MAX_PARAMETER_LEN);
@@ -507,10 +507,10 @@ void wdmp_form_get_response(res_struct *resObj, cJSON *response)
                 {
                         cJSON_AddItemToArray(parameters, resParamObj = cJSON_CreateObject());
                         
-                        WdmpPrint("WDMP-C: resObj->u.paramRes->params[%zu].name :%s\n",i,resObj->u.paramRes->params[i].name);
+                        WdmpPrint("resObj->u.paramRes->params[%zu].name :%s\n",i,resObj->u.paramRes->params[i].name);
                         cJSON_AddStringToObject(resParamObj, "name", resObj->u.paramRes->params[i].name);
                         
-                        WdmpPrint("WDMP-C: resObj->retStatus[%zu] : %d\n",i,resObj->retStatus[i]);
+                        WdmpPrint("resObj->retStatus[%zu] : %d\n",i,resObj->retStatus[i]);
                         mapWdmpStatusToStatusMessage(resObj->retStatus[i], result);
                         cJSON_AddStringToObject(resParamObj, "message", result);
                 }
@@ -526,7 +526,7 @@ void wdmp_form_get_response(res_struct *resObj, cJSON *response)
         {
                 free(result); 
         }
-        WdmpPrint("WDMP-C: statusCode : %d\n",statusCode);
+        WdmpPrint("statusCode : %d\n",statusCode);
         cJSON_AddNumberToObject(response, "statusCode", statusCode);
 }
 
@@ -537,18 +537,18 @@ void wdmp_form_table_response(res_struct *resObj, cJSON *response)
         
         result = (char *) malloc(sizeof(char) * MAX_PARAMETER_LEN);
         
-        WdmpPrint("WDMP-C: resObj->retStatus : %d\n",resObj->retStatus[0]);
+        WdmpPrint("resObj->retStatus : %d\n",resObj->retStatus[0]);
         getStatusCode(&statusCode,1,resObj->retStatus);
         
         if((resObj->u.tableRes != NULL) && (statusCode == WDMP_STATUS_SUCCESS))
         {
                        statusCode = WDMP_ADDROW_STATUS_SUCCESS; 
-                       WdmpPrint("WDMP-C: resObj->u.tableRes->newObj : %s\n",resObj->u.tableRes->newObj);
+                       WdmpPrint("resObj->u.tableRes->newObj : %s\n",resObj->u.tableRes->newObj);
                        cJSON_AddStringToObject(response, "row", resObj->u.tableRes->newObj);
         }
         
         mapWdmpStatusToStatusMessage(resObj->retStatus[0], result);
-        WdmpPrint("WDMP-C: result : %s\n",result);
+        WdmpPrint("result : %s\n",result);
         cJSON_AddStringToObject(response, "message", result);
         
         if(result)
@@ -556,7 +556,7 @@ void wdmp_form_table_response(res_struct *resObj, cJSON *response)
                 free(result); 
         }
         
-        WdmpPrint("WDMP-C: statusCode :%d\n",statusCode);
+        WdmpPrint("statusCode :%d\n",statusCode);
         cJSON_AddNumberToObject(response, "statusCode", statusCode);
 }
 
@@ -567,11 +567,11 @@ void wdmp_form_table_response(res_struct *resObj, cJSON *response)
         char *result = NULL;
         WDMP_RESPONSE_STATUS_CODE statusCode = WDMP_STATUS_GENERAL_FALURE;
         
-        WdmpPrint("WDMP-C: resObj->paramCnt : %zu\n",resObj->paramCnt);
+        WdmpPrint("resObj->paramCnt : %zu\n",resObj->paramCnt);
         paramCount = resObj->paramCnt;
-        WdmpPrint("WDMP-C: paramCount : %zu\n",paramCount);
+        WdmpPrint("paramCount : %zu\n",paramCount);
         
-        WdmpPrint("WDMP-C: resObj->retStatus : %d\n",resObj->retStatus[0]);
+        WdmpPrint("resObj->retStatus : %d\n",resObj->retStatus[0]);
         getStatusCode(&statusCode, 1, resObj->retStatus);
                 
         result = (char *) malloc(sizeof(char) * MAX_PARAMETER_LEN);
@@ -599,7 +599,7 @@ void wdmp_form_table_response(res_struct *resObj, cJSON *response)
                 free(result); 
         }
         
-        WdmpPrint("WDMP-C: statusCode : %d\n",statusCode);
+        WdmpPrint("statusCode : %d\n",statusCode);
         cJSON_AddNumberToObject(response, "statusCode", statusCode);
         
 }
@@ -749,7 +749,7 @@ void wdmp_form_table_response(res_struct *resObj, cJSON *response)
 	int i =0;
 	for (i = 0; i < paramCount; i++) 
 	{
-		WdmpPrint("WDMP-C: ret[%d] = %d\n",i,ret[i]);
+		WdmpPrint("ret[%d] = %d\n",i,ret[i]);
 		if (ret[i] == WDMP_SUCCESS) 
 		{
 			*statusCode = WDMP_STATUS_SUCCESS;
@@ -780,7 +780,7 @@ void wdmp_form_table_response(res_struct *resObj, cJSON *response)
 			break;
 		}
 	}
-	WdmpPrint("WDMP-C: *statusCode = %d\n",*statusCode);
+	WdmpPrint("*statusCode = %d\n",*statusCode);
 }
 /*----------------------------------------------------------------------------*/
 /*                             Internal functions                             */

--- a/src/wdmp_log.h
+++ b/src/wdmp_log.h
@@ -1,5 +1,5 @@
 #include <stdarg.h>
-
+#include <cimplog.h>
 
 #define LEVEL_ERROR 0
 #define LEVEL_INFO  1
@@ -7,10 +7,19 @@
 
 #define MSG_BUF_SIZE	4096
 
+#ifdef CIMP_LOGGER
+
+#define WdmpError(...)	cimplog_error("WDMP-C", __VA_ARGS__)
+#define WdmpInfo(...)	cimplog_info("WDMP-C", __VA_ARGS__)
+#define WdmpPrint(...)	cimplog_debug("WDMP-C", __VA_ARGS__)
+ 
+#else
+
 #define WdmpError(...)	wdmp_log (LEVEL_ERROR, __VA_ARGS__)
 #define WdmpInfo(...)	wdmp_log (LEVEL_INFO, __VA_ARGS__)
 #define WdmpPrint(...)	wdmp_log (LEVEL_DEBUG, __VA_ARGS__)
 
+#endif
 /**
  * @brief Handler used by wdmp_log_set_handler to receive all log
  * notifications produced by the library on this function.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,4 +25,6 @@ add_executable(simple simple.c ../src/wdmp-c.c ../src/wdmp_internal.c ../src/wdm
 target_link_libraries (simple  gcov
                                cunit
                               -lcjson 
-                              -lm)
+                              -lm
+							  -lcimplog
+							  rt)

--- a/tests/simple.c
+++ b/tests/simple.c
@@ -32,7 +32,7 @@ void get_req_parse ()
     char *request = NULL;
     req_struct *reqObj = NULL;
     
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
     
     request = "{ \"names\":[\"Device.DeviceInfo.Webpa.Enable\",\"Device.DeviceInfo.Webpa.\"],\"command\": \"GET\"}";
     
@@ -40,17 +40,17 @@ void get_req_parse ()
     
     CU_ASSERT( NULL != reqObj);
     
-    WdmpInfo("WDMP-C: Request Type : %d\n",reqObj->reqType);
+    WdmpInfo("Request Type : %d\n",reqObj->reqType);
     
     CU_ASSERT_EQUAL( GET, reqObj->reqType );
     
     if(reqObj->u.getReq)
     {
-        WdmpPrint("WDMP-C: ParamCount : %zu\n",reqObj->u.getReq->paramCnt);
+        WdmpPrint("ParamCount : %zu\n",reqObj->u.getReq->paramCnt);
         paramCount = (int)reqObj->u.getReq->paramCnt;
         for (i = 0; i < paramCount; i++) 
         {
-            WdmpPrint("WDMP-C: paramNames[%d] : %s\n",i,reqObj->u.getReq->paramNames[i]);
+            WdmpPrint("paramNames[%d] : %s\n",i,reqObj->u.getReq->paramNames[i]);
             
         }
     }
@@ -72,7 +72,7 @@ void get_attr_req_parse ()
     req_struct *reqObj = NULL;
     char * payload= NULL;
     
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
     
     payload= "{ \"names\":[\"Device.WiFi.SSID.1.Enable\",\"Device.WiFi.SSID.1.SSID\"],\"attributes\":\"notify\",\"command\": \"GET_ATTRIBUTES\"}";
     
@@ -80,7 +80,7 @@ void get_attr_req_parse ()
     
     request = cJSON_Parse(payload);
     
-    WdmpInfo("WDMP-C: Request: \n%s\n",cJSON_Print(request));
+    WdmpInfo("Request: \n%s\n",cJSON_Print(request));
     
     (reqObj) = (req_struct *) malloc(sizeof(req_struct));
     memset( (reqObj), 0, sizeof( req_struct ) );
@@ -90,12 +90,12 @@ void get_attr_req_parse ()
     CU_ASSERT( NULL != reqObj);
     CU_ASSERT_EQUAL( GET_ATTRIBUTES, reqObj->reqType );
     
-    WdmpInfo("WDMP-C: Request Type : %d\n",reqObj->reqType);
-    WdmpPrint("WDMP-C: ParamCount : %zu\n",reqObj->u.getReq->paramCnt);
+    WdmpInfo("Request Type : %d\n",reqObj->reqType);
+    WdmpPrint("ParamCount : %zu\n",reqObj->u.getReq->paramCnt);
     paramCount = (int)reqObj->u.getReq->paramCnt;
     for (i = 0; i < paramCount; i++) 
     {
-        WdmpPrint("WDMP-C: paramNames[%d] : %s\n",i,reqObj->u.getReq->paramNames[i]);
+        WdmpPrint("paramNames[%d] : %s\n",i,reqObj->u.getReq->paramNames[i]);
     }
     
     CU_ASSERT_EQUAL( 2, paramCount );
@@ -114,7 +114,7 @@ void set_req_parse ()
     char *request = NULL;
     req_struct *reqObj = NULL;
     
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
       
     request= "{\"parameters\":[{\"name\":\"Device.DeviceInfo.ProductClass\",\"value\":\"XB3\",\"dataType\":0},{\"name\":\"Device.DeviceInfo.SerialNumber\",\"value\":\"14cfe2142142\",\"dataType\":0}],\"command\":\"SET\"}";
  
@@ -123,14 +123,14 @@ void set_req_parse ()
     CU_ASSERT( NULL != reqObj);
     CU_ASSERT_EQUAL( SET, reqObj->reqType );
     
-    WdmpInfo("WDMP-C: Request Type : %d\n",reqObj->reqType);
-    WdmpPrint("WDMP-C: Param Count : %zu\n",reqObj->u.setReq->paramCnt);
+    WdmpInfo("Request Type : %d\n",reqObj->reqType);
+    WdmpPrint("Param Count : %zu\n",reqObj->u.setReq->paramCnt);
     paramCount = (int)reqObj->u.setReq->paramCnt;
     for (i = 0; i < paramCount; i++) 
 	{
-	    WdmpPrint("WDMP-C: param[%d].name : %s\n",i,reqObj->u.setReq->param[i].name);
-	    WdmpPrint("WDMP-C: param[%d].value : %s\n",i,reqObj->u.setReq->param[i].value);
-	    WdmpPrint("WDMP-C: param[%d].type : %d\n",i,reqObj->u.setReq->param[i].type);
+	    WdmpPrint("param[%d].name : %s\n",i,reqObj->u.setReq->param[i].name);
+	    WdmpPrint("param[%d].value : %s\n",i,reqObj->u.setReq->param[i].value);
+	    WdmpPrint("param[%d].type : %d\n",i,reqObj->u.setReq->param[i].type);
 	}
 	
     CU_ASSERT_EQUAL( 2, paramCount );
@@ -154,7 +154,7 @@ void set_req_parse_with_attributes ()
     char *request = NULL;
     req_struct *reqObj = NULL;
     
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
       
     request= "{\"parameters\":[{\"name\":\"Device.DeviceInfo.ProductClass\",\"value\":\"XB3\",\"dataType\":0,\"attributes\": { \"notify\": 1}},{\"name\":\"Device.DeviceInfo.SerialNumber\",\"value\":\"14cfe2142142\",\"dataType\":0,\"attributes\": { \"notify\": 1}}],\"command\":\"SET\"}";
  
@@ -163,14 +163,14 @@ void set_req_parse_with_attributes ()
     CU_ASSERT( NULL != reqObj);
     CU_ASSERT_EQUAL( SET, reqObj->reqType );
     
-    WdmpInfo("WDMP-C: Request Type : %d\n",reqObj->reqType);
-    WdmpPrint("WDMP-C: Param Count : %zu\n",reqObj->u.setReq->paramCnt);
+    WdmpInfo("Request Type : %d\n",reqObj->reqType);
+    WdmpPrint("Param Count : %zu\n",reqObj->u.setReq->paramCnt);
     paramCount = (int)reqObj->u.setReq->paramCnt;
     for (i = 0; i < paramCount; i++) 
 	{
-	    WdmpPrint("WDMP-C: param[%d].name : %s\n",i,reqObj->u.setReq->param[i].name);
-	    WdmpPrint("WDMP-C: param[%d].value : %s\n",i,reqObj->u.setReq->param[i].value);
-	    WdmpPrint("WDMP-C: param[%d].type : %d\n",i,reqObj->u.setReq->param[i].type);
+	    WdmpPrint("param[%d].name : %s\n",i,reqObj->u.setReq->param[i].name);
+	    WdmpPrint("param[%d].value : %s\n",i,reqObj->u.setReq->param[i].value);
+	    WdmpPrint("param[%d].type : %d\n",i,reqObj->u.setReq->param[i].type);
 	}
 	
     CU_ASSERT_EQUAL( 2, paramCount );
@@ -195,7 +195,7 @@ void set_attr_req_parse ()
     req_struct *reqObj = NULL;
     char * payload= NULL;
     
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
       
     payload = "{\"parameters\":[{\"name\":\"Device.DeviceInfo.ProductClass\",\"attributes\": { \"notify\": 1}},{\"name\":\"Device.DeviceInfo.SerialNumber\",\"attributes\": { \"notify\": 0}}],\"command\":\"SET_ATTRIBUTES\"}";
  
@@ -203,7 +203,7 @@ void set_attr_req_parse ()
     
     request = cJSON_Parse(payload);
     
-    WdmpInfo("WDMP-C: Request: \n%s\n",cJSON_Print(request));
+    WdmpInfo("Request: \n%s\n",cJSON_Print(request));
     
     (reqObj) = (req_struct *) malloc(sizeof(req_struct));
     memset( (reqObj), 0, sizeof( req_struct ) );
@@ -213,14 +213,14 @@ void set_attr_req_parse ()
     CU_ASSERT( NULL != reqObj);
     CU_ASSERT_EQUAL( SET_ATTRIBUTES, reqObj->reqType );
     
-    WdmpInfo("WDMP-C: Request Type : %d\n",reqObj->reqType);
-    WdmpPrint("WDMP-C: Param Count : %zu\n",reqObj->u.setReq->paramCnt);
+    WdmpInfo("Request Type : %d\n",reqObj->reqType);
+    WdmpPrint("Param Count : %zu\n",reqObj->u.setReq->paramCnt);
     paramCount = (int)reqObj->u.setReq->paramCnt;
     for (i = 0; i < paramCount; i++) 
     {
-        WdmpPrint("WDMP-C: param[%d].name : %s\n",i,reqObj->u.setReq->param[i].name);
-        WdmpPrint("WDMP-C: param[%d].value : %s\n",i,reqObj->u.setReq->param[i].value);
-        WdmpPrint("WDMP-C: param[%d].type : %d\n",i,reqObj->u.setReq->param[i].type);
+        WdmpPrint("param[%d].name : %s\n",i,reqObj->u.setReq->param[i].name);
+        WdmpPrint("param[%d].value : %s\n",i,reqObj->u.setReq->param[i].value);
+        WdmpPrint("param[%d].type : %d\n",i,reqObj->u.setReq->param[i].type);
     }
 	
     CU_ASSERT_EQUAL( 2, paramCount );
@@ -244,7 +244,7 @@ void test_and_set_req_parse ()
     req_struct *reqObj = NULL;
     char * payload= NULL;
     
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
       
     payload = "{\"parameters\":[{\"name\":\"Device.DeviceInfo.ProductClass\",\"value\":\"XB3\",\"dataType\":0},{\"name\":\"Device.DeviceInfo.SerialNumber\",\"value\":\"14cfe2142142\",\"dataType\":0}],\"new-cid\":\"1234\",\"old-cid\":\"aq12\",\"sync-cmc\":\"512\",\"command\":\"TEST_AND_SET\"}";
  
@@ -252,7 +252,7 @@ void test_and_set_req_parse ()
     
     request = cJSON_Parse(payload);
     
-    WdmpInfo("WDMP-C: Request: \n%s\n",cJSON_Print(request));
+    WdmpInfo("Request: \n%s\n",cJSON_Print(request));
     
     (reqObj) = (req_struct *) malloc(sizeof(req_struct));
     memset( (reqObj), 0, sizeof( req_struct ) );
@@ -262,11 +262,11 @@ void test_and_set_req_parse ()
     CU_ASSERT( NULL != reqObj);
     CU_ASSERT_EQUAL( TEST_AND_SET, reqObj->reqType );
     
-    WdmpInfo("WDMP-C: Request Type : %d\n",reqObj->reqType);
-    WdmpPrint("WDMP-C: Param Count : %zu\n",reqObj->u.testSetReq->paramCnt);
-    WdmpInfo("WDMP-C: New Cid : %s\n",reqObj->u.testSetReq->newCid);
-    WdmpInfo("WDMP-C: Old Cid : %s\n",reqObj->u.testSetReq->oldCid);
-    WdmpInfo("WDMP-C: Sync Cmc : %s\n",reqObj->u.testSetReq->syncCmc);
+    WdmpInfo("Request Type : %d\n",reqObj->reqType);
+    WdmpPrint("Param Count : %zu\n",reqObj->u.testSetReq->paramCnt);
+    WdmpInfo("New Cid : %s\n",reqObj->u.testSetReq->newCid);
+    WdmpInfo("Old Cid : %s\n",reqObj->u.testSetReq->oldCid);
+    WdmpInfo("Sync Cmc : %s\n",reqObj->u.testSetReq->syncCmc);
     
     CU_ASSERT_STRING_EQUAL( "1234", reqObj->u.testSetReq->newCid ); 
     CU_ASSERT_STRING_EQUAL( "aq12", reqObj->u.testSetReq->oldCid ); 
@@ -276,9 +276,9 @@ void test_and_set_req_parse ()
     
     for (i = 0; i < paramCount; i++) 
     {
-	    WdmpPrint("WDMP-C: param[%d].name : %s\n",i,reqObj->u.testSetReq->param[i].name);
-	    WdmpPrint("WDMP-C: param[%d].value : %s\n",i,reqObj->u.testSetReq->param[i].value);
-	    WdmpPrint("WDMP-C: param[%d].type : %d\n",i,reqObj->u.testSetReq->param[i].type);
+	    WdmpPrint("param[%d].name : %s\n",i,reqObj->u.testSetReq->param[i].name);
+	    WdmpPrint("param[%d].value : %s\n",i,reqObj->u.testSetReq->param[i].value);
+	    WdmpPrint("param[%d].type : %d\n",i,reqObj->u.testSetReq->param[i].type);
     }
     
     CU_ASSERT_EQUAL( 2, paramCount );
@@ -303,7 +303,7 @@ void replace_rows_req_parse ()
     req_struct *reqObj = NULL;
     char * payload= NULL;
     
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
        
     payload= "{\"rows\":{\"0\":{\"DeviceName\":\"Device1\",\"MacAddress\":\"12:2:3:5:11\"},\"1\":{\"DeviceName\":\"Device2\",\"MacAddress\":\"2:1:3:5:7\"} },\"table\" : \"Device.WiFi.AccessPoint.10001.X_CISCO_COM_MacFilterTable.\",\"command\":\"REPLACE_ROWS\"}";
  
@@ -311,7 +311,7 @@ void replace_rows_req_parse ()
     
     request = cJSON_Parse(payload);
     
-    WdmpInfo("WDMP-C: Request: \n%s\n",cJSON_Print(request));
+    WdmpInfo("Request: \n%s\n",cJSON_Print(request));
     
     (reqObj) = (req_struct *) malloc(sizeof(req_struct));
     memset( (reqObj), 0, sizeof( req_struct ) );
@@ -321,22 +321,22 @@ void replace_rows_req_parse ()
     CU_ASSERT( NULL != reqObj);
     CU_ASSERT_EQUAL( REPLACE_ROWS, reqObj->reqType );
     
-    WdmpInfo("WDMP-C: Req Type : %d\n",reqObj->reqType);
-    WdmpInfo("WDMP-C: Object Name : %s\n",reqObj->u.tableReq->objectName);
-    WdmpInfo("WDMP-C: Row Count : %zu\n",reqObj->u.tableReq->rowCnt);
+    WdmpInfo("Req Type : %d\n",reqObj->reqType);
+    WdmpInfo("Object Name : %s\n",reqObj->u.tableReq->objectName);
+    WdmpInfo("Row Count : %zu\n",reqObj->u.tableReq->rowCnt);
     rowCnt = (int)reqObj->u.tableReq->rowCnt;
     CU_ASSERT_STRING_EQUAL( "Device.WiFi.AccessPoint.10001.X_CISCO_COM_MacFilterTable.", reqObj->u.tableReq->objectName );
     CU_ASSERT_EQUAL( 2, rowCnt );
     
     for ( i = 0 ; i < rowCnt ; i++)
     {
-        WdmpPrint("WDMP-C: ParamCount: %zu\n",reqObj->u.tableReq->rows[i].paramCnt);
+        WdmpPrint("ParamCount: %zu\n",reqObj->u.tableReq->rows[i].paramCnt);
         paramCount = (int)reqObj->u.tableReq->rows[i].paramCnt;
         
         for( j = 0 ; j < paramCount ; j++)
         {
-	        WdmpPrint("WDMP-C: rows[%d].names[%d] : %s\n",i,j,reqObj->u.tableReq->rows[i].names[j]);				
-	        WdmpPrint("WDMP-C: rows[%d].values[%d] : %s\n",i,j,reqObj->u.tableReq->rows[i].values[j]);			
+	        WdmpPrint("rows[%d].names[%d] : %s\n",i,j,reqObj->u.tableReq->rows[i].names[j]);				
+	        WdmpPrint("rows[%d].values[%d] : %s\n",i,j,reqObj->u.tableReq->rows[i].values[j]);			
         }
     }
     
@@ -359,7 +359,7 @@ void add_row_req_parse ()
     req_struct *reqObj = NULL;
     char * payload= NULL;
     
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
 
     payload = "{\"row\":{\"DeviceName\":\"Device1\",\"MacAddress\":\"12:2:3:5:11\"},\"table\":\"Device.WiFi.AccessPoint.10001.X_CISCO_COM_MacFilterTable.\",\"command\":\"ADD_ROW\"}";
  
@@ -367,7 +367,7 @@ void add_row_req_parse ()
     
     request = cJSON_Parse(payload);
     
-    WdmpInfo("WDMP-C: Request: \n%s\n",cJSON_Print(request));
+    WdmpInfo("Request: \n%s\n",cJSON_Print(request));
     
     (reqObj) = (req_struct *) malloc(sizeof(req_struct));
     memset( (reqObj), 0, sizeof( req_struct ) );
@@ -377,9 +377,9 @@ void add_row_req_parse ()
     CU_ASSERT( NULL != reqObj);
     CU_ASSERT_EQUAL( ADD_ROWS, reqObj->reqType );
     
-    WdmpInfo("WDMP-C: Req Type : %d\n",reqObj->reqType);
-    WdmpInfo("WDMP-C: Object Name : %s\n",reqObj->u.tableReq->objectName);
-    WdmpInfo("WDMP-C: Row Count : %zu\n",reqObj->u.tableReq->rowCnt);
+    WdmpInfo("Req Type : %d\n",reqObj->reqType);
+    WdmpInfo("Object Name : %s\n",reqObj->u.tableReq->objectName);
+    WdmpInfo("Row Count : %zu\n",reqObj->u.tableReq->rowCnt);
     
     CU_ASSERT_STRING_EQUAL( "Device.WiFi.AccessPoint.10001.X_CISCO_COM_MacFilterTable.", reqObj->u.tableReq->objectName );
     CU_ASSERT_EQUAL( 1, reqObj->u.tableReq->rowCnt );
@@ -387,13 +387,13 @@ void add_row_req_parse ()
     
     for ( i = 0 ; i < rowCnt ; i++)
     {
-        WdmpPrint("WDMP-C: ParamCount: %zu\n",reqObj->u.tableReq->rows[i].paramCnt);
+        WdmpPrint("ParamCount: %zu\n",reqObj->u.tableReq->rows[i].paramCnt);
         paramCount = (int)reqObj->u.tableReq->rows[i].paramCnt;
         
         for( j = 0 ; j < paramCount ; j++)
         {
-	        WdmpPrint("WDMP-C: rows[%d].names[%d] : %s\n",i,j,reqObj->u.tableReq->rows[i].names[j]);				
-	        WdmpPrint("WDMP-C: rows[%d].values[%d] : %s\n",i,j,reqObj->u.tableReq->rows[i].values[j]);			
+	        WdmpPrint("rows[%d].names[%d] : %s\n",i,j,reqObj->u.tableReq->rows[i].names[j]);				
+	        WdmpPrint("rows[%d].values[%d] : %s\n",i,j,reqObj->u.tableReq->rows[i].values[j]);			
         }
     }
     
@@ -415,7 +415,7 @@ void delete_row_req_parse ()
     req_struct *reqObj = NULL;
     char * payload= NULL;
     
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
     
     payload = "{\"row\":\"Device.WiFi.AccessPoint.10001.X_CISCO_COM_MacFilterTable.1.\",\"command\":\"DELETE_ROW\"}";
  
@@ -423,7 +423,7 @@ void delete_row_req_parse ()
     
     request = cJSON_Parse(payload);
     
-    WdmpInfo("WDMP-C: Request: \n%s\n",cJSON_Print(request));
+    WdmpInfo("Request: \n%s\n",cJSON_Print(request));
     
     (reqObj) = (req_struct *) malloc(sizeof(req_struct));
     memset( (reqObj), 0, sizeof( req_struct ) );
@@ -433,9 +433,9 @@ void delete_row_req_parse ()
     CU_ASSERT( NULL != reqObj);
     CU_ASSERT_EQUAL( DELETE_ROW, reqObj->reqType );
     
-    WdmpInfo("WDMP-C: Req Type : %d\n",reqObj->reqType);
-    WdmpInfo("WDMP-C: Object Name : %s\n",reqObj->u.tableReq->objectName);
-    WdmpInfo("WDMP-C: Row Count : %zu\n",reqObj->u.tableReq->rowCnt);
+    WdmpInfo("Req Type : %d\n",reqObj->reqType);
+    WdmpInfo("Object Name : %s\n",reqObj->u.tableReq->objectName);
+    WdmpInfo("Row Count : %zu\n",reqObj->u.tableReq->rowCnt);
     CU_ASSERT_STRING_EQUAL( "Device.WiFi.AccessPoint.10001.X_CISCO_COM_MacFilterTable.1.", reqObj->u.tableReq->objectName );
     CU_ASSERT_EQUAL( 0, reqObj->u.tableReq->rowCnt );
 
@@ -447,7 +447,7 @@ void delete_row_req_parse ()
 
 void test_unknown_command ()
 {
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
     
     req_struct *reqObj = NULL;
     char * request= "{ \"names\":[\"Device.DeviceInfo.Webpa.Enable\",\"Device.WiFi.SSID.1.Enable\"],\"command\": \"UNKNOWN\"}";
@@ -462,7 +462,7 @@ void test_unknown_command ()
 
 void get_req_empty_names ()
 {
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
     int paramCount;
     req_struct *reqObj = NULL;
     char * request= "{ \"names\":\" \",\"command\": \"GET\"}";
@@ -470,13 +470,13 @@ void get_req_empty_names ()
     
     CU_ASSERT( NULL != reqObj);
     
-    WdmpInfo("WDMP-C: Request Type : %d\n",reqObj->reqType);
+    WdmpInfo("Request Type : %d\n",reqObj->reqType);
     
     CU_ASSERT_EQUAL( GET, reqObj->reqType );
     
     if(reqObj->u.getReq)
     {
-        WdmpPrint("WDMP-C: ParamCount : %zu\n",reqObj->u.getReq->paramCnt);
+        WdmpPrint("ParamCount : %zu\n",reqObj->u.getReq->paramCnt);
         paramCount = (int)reqObj->u.getReq->paramCnt;
         CU_ASSERT_EQUAL( 0, paramCount );
         
@@ -490,7 +490,7 @@ void get_req_empty_names ()
 
 void get_req_empty_notify ()
 {
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
     req_struct *reqObj = NULL;
     
     char * request= "{ \"names\":[\"Device.WiFi.SSID.1.Enable\",\"Device.WiFi.SSID.1.SSID\"],\"attributes\":\"\",\"command\": \"GET_ATTRIBUTES\"}";
@@ -505,7 +505,7 @@ void get_req_empty_notify ()
 
 void set_req_empty_notify ()
 {
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
     
     int i,paramCount;
     req_struct *reqObj = NULL;
@@ -517,14 +517,14 @@ void set_req_empty_notify ()
     CU_ASSERT( NULL != reqObj);
     CU_ASSERT_EQUAL( SET_ATTRIBUTES, reqObj->reqType );
     
-    WdmpInfo("WDMP-C: Request Type : %d\n",reqObj->reqType);
-    WdmpPrint("WDMP-C: Param Count : %zu\n",reqObj->u.setReq->paramCnt);
+    WdmpInfo("Request Type : %d\n",reqObj->reqType);
+    WdmpPrint("Param Count : %zu\n",reqObj->u.setReq->paramCnt);
     paramCount = (int)reqObj->u.setReq->paramCnt;
     for (i = 0; i < paramCount; i++) 
 	{
-	    WdmpPrint("WDMP-C: param[%d].name : %s\n",i,reqObj->u.setReq->param[i].name);
-	    WdmpPrint("WDMP-C: param[%d].value : %s\n",i,reqObj->u.setReq->param[i].value);
-	    WdmpPrint("WDMP-C: param[%d].type : %d\n",i,reqObj->u.setReq->param[i].type);
+	    WdmpPrint("param[%d].name : %s\n",i,reqObj->u.setReq->param[i].name);
+	    WdmpPrint("param[%d].value : %s\n",i,reqObj->u.setReq->param[i].value);
+	    WdmpPrint("param[%d].type : %d\n",i,reqObj->u.setReq->param[i].type);
 	}	
     CU_ASSERT( NULL == reqObj->u.setReq->param[0].value );
    
@@ -535,7 +535,7 @@ void set_req_empty_notify ()
 
 void test_and_set_without_cid ()
 {
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
     int i,paramCount;
     req_struct *reqObj = NULL;
       
@@ -543,9 +543,9 @@ void test_and_set_without_cid ()
  
     wdmp_parse_request(request,&reqObj);
 
-    WdmpInfo("WDMP-C: Request Type : %d\n",reqObj->reqType);    
-    WdmpInfo("WDMP-C: New Cid : %s\n",reqObj->u.testSetReq->newCid); 
-    WdmpInfo("WDMP-C: Old Cid : %s\n",reqObj->u.testSetReq->oldCid);    
+    WdmpInfo("Request Type : %d\n",reqObj->reqType);    
+    WdmpInfo("New Cid : %s\n",reqObj->u.testSetReq->newCid); 
+    WdmpInfo("Old Cid : %s\n",reqObj->u.testSetReq->oldCid);    
     
     CU_ASSERT( NULL != reqObj);    
     CU_ASSERT ( NULL == reqObj->u.testSetReq->newCid ); 
@@ -557,9 +557,9 @@ void test_and_set_without_cid ()
     
     for (i = 0; i < paramCount; i++) 
     {
-	    WdmpPrint("WDMP-C: param[%d].name : %s\n",i,reqObj->u.testSetReq->param[i].name);
-	    WdmpPrint("WDMP-C: param[%d].value : %s\n",i,reqObj->u.testSetReq->param[i].value);
-	    WdmpPrint("WDMP-C: param[%d].type : %d\n",i,reqObj->u.testSetReq->param[i].type);
+	    WdmpPrint("param[%d].name : %s\n",i,reqObj->u.testSetReq->param[i].name);
+	    WdmpPrint("param[%d].value : %s\n",i,reqObj->u.testSetReq->param[i].value);
+	    WdmpPrint("param[%d].type : %d\n",i,reqObj->u.testSetReq->param[i].type);
     }
     
     CU_ASSERT_EQUAL( 1, paramCount );
@@ -576,7 +576,7 @@ void test_and_set_without_cid ()
 
 void empty_test_and_set ()
 {
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
     
     req_struct *reqObj = NULL;
       
@@ -584,9 +584,9 @@ void empty_test_and_set ()
 
     wdmp_parse_request(request,&reqObj);
 
-    WdmpInfo("WDMP-C: Request Type : %d\n",reqObj->reqType);    
-    WdmpInfo("WDMP-C: New Cid : %s\n",reqObj->u.testSetReq->newCid);    
-    WdmpPrint("WDMP-C: param struct is %s\n", (char*)reqObj->u.testSetReq->param);
+    WdmpInfo("Request Type : %d\n",reqObj->reqType);    
+    WdmpInfo("New Cid : %s\n",reqObj->u.testSetReq->newCid);    
+    WdmpPrint("param struct is %s\n", (char*)reqObj->u.testSetReq->param);
     CU_ASSERT( NULL != reqObj);
     CU_ASSERT_EQUAL( TEST_AND_SET, reqObj->reqType );
     CU_ASSERT(NULL == reqObj->u.testSetReq->param);   
@@ -599,7 +599,7 @@ void empty_test_and_set ()
 
 void set_req_null_param_value ()
 {
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
     
     int i,paramCount;
     req_struct *reqObj = NULL;
@@ -611,14 +611,14 @@ void set_req_null_param_value ()
     CU_ASSERT( NULL != reqObj);
     CU_ASSERT_EQUAL( SET, reqObj->reqType );
     
-    WdmpInfo("WDMP-C: Request Type : %d\n",reqObj->reqType);
-    WdmpInfo("WDMP-C: Param Count : %zu\n",reqObj->u.setReq->paramCnt);
+    WdmpInfo("Request Type : %d\n",reqObj->reqType);
+    WdmpInfo("Param Count : %zu\n",reqObj->u.setReq->paramCnt);
     paramCount = (int)reqObj->u.setReq->paramCnt;
     for (i = 0; i < paramCount; i++) 
 	{
-	    WdmpPrint("WDMP-C: param[%d].name : %s\n",i,reqObj->u.setReq->param[i].name);
-	    WdmpPrint("WDMP-C: param[%d].value : %s\n",i,reqObj->u.setReq->param[i].value);
-	    WdmpPrint("WDMP-C: param[%d].type : %d\n",i,reqObj->u.setReq->param[i].type);
+	    WdmpPrint("param[%d].name : %s\n",i,reqObj->u.setReq->param[i].name);
+	    WdmpPrint("param[%d].value : %s\n",i,reqObj->u.setReq->param[i].value);
+	    WdmpPrint("param[%d].type : %d\n",i,reqObj->u.setReq->param[i].type);
 	}
 	
     CU_ASSERT_EQUAL( 2, paramCount );
@@ -637,7 +637,7 @@ void set_req_null_param_value ()
 
 void set_req_value_field_empty ()
 {
-    WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+    WdmpInfo("\n***************************************************** \n\n");
     
     int paramCount;
     req_struct *reqObj = NULL;
@@ -647,12 +647,12 @@ void set_req_value_field_empty ()
     wdmp_parse_request(request,&reqObj);
     
     CU_ASSERT( NULL != reqObj);
-    WdmpPrint("WDMP-C: Param Count : %zu\n",reqObj->u.setReq->paramCnt);
+    WdmpPrint("Param Count : %zu\n",reqObj->u.setReq->paramCnt);
     paramCount = (int)reqObj->u.setReq->paramCnt;
     
-    WdmpPrint("WDMP-C: param.name : %s\n",reqObj->u.setReq->param[0].name);
-    WdmpPrint("WDMP-C: param.value : %s\n",reqObj->u.setReq->param[0].value);
-    WdmpPrint("WDMP-C: param.type : %d\n",reqObj->u.setReq->param[0].type);
+    WdmpPrint("param.name : %s\n",reqObj->u.setReq->param[0].name);
+    WdmpPrint("param.value : %s\n",reqObj->u.setReq->param[0].value);
+    WdmpPrint("param.type : %d\n",reqObj->u.setReq->param[0].type);
 	
     CU_ASSERT_EQUAL( 1, paramCount );
     CU_ASSERT_STRING_EQUAL( "Device.DeviceInfo.HardwareVersion", reqObj->u.setReq->param[0].name );
@@ -672,7 +672,7 @@ void verify_get_reponse(cJSON *response, res_struct *resObj)
         WDMP_RESPONSE_STATUS_CODE statusCode;
         char *result = NULL;
         
-        WdmpInfo("WDMP-C: Status code: %d\n", cJSON_GetObjectItem(response, "statusCode")->valueint);
+        WdmpInfo("Status code: %d\n", cJSON_GetObjectItem(response, "statusCode")->valueint);
         getStatusCode(&statusCode, resObj->paramCnt, resObj->retStatus);
         CU_ASSERT_EQUAL((int)statusCode, cJSON_GetObjectItem(response, "statusCode")->valueint);
         
@@ -680,7 +680,7 @@ void verify_get_reponse(cJSON *response, res_struct *resObj)
         
         CU_ASSERT( NULL != paramArray );
         
-        WdmpPrint("WDMP-C: Parameter count: %d\n",cJSON_GetArraySize(paramArray));
+        WdmpPrint("Parameter count: %d\n",cJSON_GetArraySize(paramArray));
         CU_ASSERT_EQUAL( (int)resObj->paramCnt, cJSON_GetArraySize(paramArray) );
         
         result = (char *) malloc(sizeof(char) * MAX_PARAMETER_LEN);
@@ -689,12 +689,12 @@ void verify_get_reponse(cJSON *response, res_struct *resObj)
 	{
 		resParamObj = cJSON_GetArrayItem(paramArray, i);
 		
-		WdmpPrint("WDMP-C: Returnparamcount[%zu]: %d\n",i, cJSON_GetObjectItem(resParamObj, "parameterCount")->valueint); 
+		WdmpPrint("Returnparamcount[%zu]: %d\n",i, cJSON_GetObjectItem(resParamObj, "parameterCount")->valueint); 
 		CU_ASSERT_EQUAL((int)resObj->u.getRes->retParamCnt[i],cJSON_GetObjectItem(resParamObj, "parameterCount")->valueint);
 		
 		if( resObj->u.getRes->retParamCnt[i] > 1)
 		{
-		        WdmpPrint("WDMP-C: ParamName[%zu] : %s\n",i, cJSON_GetObjectItem(resParamObj, "name")->valuestring);
+		        WdmpPrint("ParamName[%zu] : %s\n",i, cJSON_GetObjectItem(resParamObj, "name")->valuestring);
 		        CU_ASSERT_STRING_EQUAL( resObj->u.getRes->paramNames[i], cJSON_GetObjectItem(resParamObj, "name")->valuestring );
 		        
 		        value = cJSON_GetObjectItem(resParamObj, "value");
@@ -705,18 +705,18 @@ void verify_get_reponse(cJSON *response, res_struct *resObj)
 		        {
 		                valueObj = cJSON_GetArrayItem(value, j);
 		                
-		                WdmpPrint("WDMP-C: Name[%zu][%zu] : %s\n", i,j,cJSON_GetObjectItem(valueObj, "name")->valuestring );
+		                WdmpPrint("Name[%zu][%zu] : %s\n", i,j,cJSON_GetObjectItem(valueObj, "name")->valuestring );
 		                CU_ASSERT_STRING_EQUAL( resObj->u.getRes->params[i][j].name, cJSON_GetObjectItem(valueObj, "name")->valuestring );
-		                WdmpPrint("WDMP-C: Value[%zu][%zu] : %s\n", i,j,cJSON_GetObjectItem(valueObj, "value")->valuestring );
+		                WdmpPrint("Value[%zu][%zu] : %s\n", i,j,cJSON_GetObjectItem(valueObj, "value")->valuestring );
 		                CU_ASSERT_STRING_EQUAL( resObj->u.getRes->params[i][j].value, cJSON_GetObjectItem(valueObj, "value")->valuestring );
-		                WdmpPrint("WDMP-C: Type[%zu][%zu] : %d\n", i,j,cJSON_GetObjectItem(valueObj, "dataType")->valueint);
+		                WdmpPrint("Type[%zu][%zu] : %d\n", i,j,cJSON_GetObjectItem(valueObj, "dataType")->valueint);
 	                        CU_ASSERT_EQUAL((int)resObj->u.getRes->params[i][j].type,cJSON_GetObjectItem(valueObj, "dataType")->valueint);
 		        }
 		        
-		        WdmpPrint("WDMP-C: DataType[%zu] : %d\n",i, cJSON_GetObjectItem(resParamObj, "dataType")->valueint);
+		        WdmpPrint("DataType[%zu] : %d\n",i, cJSON_GetObjectItem(resParamObj, "dataType")->valueint);
 		        CU_ASSERT_EQUAL( WDMP_NONE, cJSON_GetObjectItem(resParamObj, "dataType")->valueint );
 		        
-		        WdmpPrint("WDMP-C: Message[%zu] : %s\n",i,cJSON_GetObjectItem(resParamObj, "message")->valuestring);
+		        WdmpPrint("Message[%zu] : %s\n",i,cJSON_GetObjectItem(resParamObj, "message")->valuestring);
 		        mapWdmpStatusToStatusMessage(resObj->retStatus[i], result);
                         CU_ASSERT_STRING_EQUAL(result, cJSON_GetObjectItem(resParamObj, "message")->valuestring);
 		        
@@ -724,25 +724,25 @@ void verify_get_reponse(cJSON *response, res_struct *resObj)
 		else if( resObj->u.getRes->retParamCnt[i] == 1)
 		{
 		        j = 0;
-		        WdmpPrint("WDMP-C: ParamName[%zu] : %s\n",i, cJSON_GetObjectItem(resParamObj, "name")->valuestring);
+		        WdmpPrint("ParamName[%zu] : %s\n",i, cJSON_GetObjectItem(resParamObj, "name")->valuestring);
 		        CU_ASSERT_STRING_EQUAL( resObj->u.getRes->paramNames[i], cJSON_GetObjectItem(resParamObj, "name")->valuestring );
-		        WdmpPrint("WDMP-C: Name[%zu][%zu] : %s\n", i,j,cJSON_GetObjectItem(resParamObj, "name")->valuestring );
+		        WdmpPrint("Name[%zu][%zu] : %s\n", i,j,cJSON_GetObjectItem(resParamObj, "name")->valuestring );
 	                CU_ASSERT_STRING_EQUAL( resObj->u.getRes->params[i][j].name, cJSON_GetObjectItem(resParamObj, "name")->valuestring );
-	                WdmpPrint("WDMP-C: Value[%zu][%zu] : %s\n", i,j,cJSON_GetObjectItem(resParamObj, "value")->valuestring );
+	                WdmpPrint("Value[%zu][%zu] : %s\n", i,j,cJSON_GetObjectItem(resParamObj, "value")->valuestring );
 	                CU_ASSERT_STRING_EQUAL( resObj->u.getRes->params[i][j].value, cJSON_GetObjectItem(resParamObj, "value")->valuestring );
-	                WdmpPrint("WDMP-C: Type[%zu][%zu] : %d\n", i,j,cJSON_GetObjectItem(resParamObj, "dataType")->valueint);
+	                WdmpPrint("Type[%zu][%zu] : %d\n", i,j,cJSON_GetObjectItem(resParamObj, "dataType")->valueint);
                         CU_ASSERT_EQUAL((int)resObj->u.getRes->params[i][j].type,cJSON_GetObjectItem(resParamObj, "dataType")->valueint);
                         
-                        WdmpPrint("WDMP-C: Message[%zu] : %s\n",i,cJSON_GetObjectItem(resParamObj, "message")->valuestring);
+                        WdmpPrint("Message[%zu] : %s\n",i,cJSON_GetObjectItem(resParamObj, "message")->valuestring);
                         mapWdmpStatusToStatusMessage(resObj->retStatus[i], result);
                         CU_ASSERT_STRING_EQUAL(result, cJSON_GetObjectItem(resParamObj, "message")->valuestring);
 		}
 		else
 		{
-                        WdmpPrint("WDMP-C: ParamName[%zu] : %s\n",i, cJSON_GetObjectItem(resParamObj, "name")->valuestring);
+                        WdmpPrint("ParamName[%zu] : %s\n",i, cJSON_GetObjectItem(resParamObj, "name")->valuestring);
                         CU_ASSERT_STRING_EQUAL( resObj->u.getRes->paramNames[i], cJSON_GetObjectItem(resParamObj, "name")->valuestring );
                          
-                        WdmpPrint("WDMP-C: Value[%zu] : %s\n", i,cJSON_GetObjectItem(resParamObj, "value")->valuestring );
+                        WdmpPrint("Value[%zu] : %s\n", i,cJSON_GetObjectItem(resParamObj, "value")->valuestring );
 	                CU_ASSERT_STRING_EQUAL( "EMPTY", cJSON_GetObjectItem(resParamObj, "value")->valuestring );   
 		}
 	}
@@ -761,7 +761,7 @@ void verify_param_response(cJSON *response, res_struct *resObj)
         WDMP_RESPONSE_STATUS_CODE statusCode;
         char *result = NULL;
         
-        WdmpInfo("WDMP-C: Status code: %d\n", cJSON_GetObjectItem(response, "statusCode")->valueint);
+        WdmpInfo("Status code: %d\n", cJSON_GetObjectItem(response, "statusCode")->valueint);
         getStatusCode(&statusCode, resObj->paramCnt, resObj->retStatus);
         CU_ASSERT_EQUAL((int)statusCode, cJSON_GetObjectItem(response, "statusCode")->valueint);
         
@@ -769,7 +769,7 @@ void verify_param_response(cJSON *response, res_struct *resObj)
         
         CU_ASSERT( NULL != paramArray );
         
-        WdmpPrint("WDMP-C: Parameter count: %d\n",cJSON_GetArraySize(paramArray));
+        WdmpPrint("Parameter count: %d\n",cJSON_GetArraySize(paramArray));
         CU_ASSERT_EQUAL( (int)resObj->paramCnt, cJSON_GetArraySize(paramArray) );
         
         result = (char *) malloc(sizeof(char) * MAX_PARAMETER_LEN);
@@ -777,17 +777,17 @@ void verify_param_response(cJSON *response, res_struct *resObj)
         for (i = 0; i < resObj->paramCnt; i++) 
 	{
 		resParamObj = cJSON_GetArrayItem(paramArray, i);
-		WdmpPrint("WDMP-C: Name[%zu] : %s\n", i,cJSON_GetObjectItem(resParamObj, "name")->valuestring );
+		WdmpPrint("Name[%zu] : %s\n", i,cJSON_GetObjectItem(resParamObj, "name")->valuestring );
                 CU_ASSERT_STRING_EQUAL( resObj->u.paramRes->params[i].name, cJSON_GetObjectItem(resParamObj, "name")->valuestring );
                 
                 if(resObj->reqType == GET_ATTRIBUTES)
                 {
                         attributes = cJSON_GetObjectItem(resParamObj, "attributes");
                         CU_ASSERT( NULL != attributes );
-                        WdmpPrint("WDMP-C: Value[%zu] : %d\n", i,cJSON_GetObjectItem(attributes, "notify")->valueint );
+                        WdmpPrint("Value[%zu] : %d\n", i,cJSON_GetObjectItem(attributes, "notify")->valueint );
                         CU_ASSERT_EQUAL( atoi(resObj->u.paramRes->params[i].value), cJSON_GetObjectItem(attributes, "notify")->valueint );
                 }
-                WdmpPrint("WDMP-C: Message[%zu] : %s\n",i,cJSON_GetObjectItem(resParamObj, "message")->valuestring);
+                WdmpPrint("Message[%zu] : %s\n",i,cJSON_GetObjectItem(resParamObj, "message")->valuestring);
                 mapWdmpStatusToStatusMessage(resObj->retStatus[i], result);
                 CU_ASSERT_STRING_EQUAL(result, cJSON_GetObjectItem(resParamObj, "message")->valuestring);
 	}
@@ -806,7 +806,7 @@ void verify_testandset_response(cJSON *response, res_struct *resObj)
         WDMP_RESPONSE_STATUS_CODE statusCode;
         char *result = NULL;
         
-        WdmpInfo("WDMP-C: Status code: %d\n", cJSON_GetObjectItem(response, "statusCode")->valueint);
+        WdmpInfo("Status code: %d\n", cJSON_GetObjectItem(response, "statusCode")->valueint);
         getStatusCode(&statusCode, 1, resObj->retStatus);
         CU_ASSERT_EQUAL((int)statusCode, cJSON_GetObjectItem(response, "statusCode")->valueint);
         
@@ -814,7 +814,7 @@ void verify_testandset_response(cJSON *response, res_struct *resObj)
         
         CU_ASSERT( NULL != paramArray );
         
-        WdmpPrint("WDMP-C: Parameter count: %d\n",cJSON_GetArraySize(paramArray));
+        WdmpPrint("Parameter count: %d\n",cJSON_GetArraySize(paramArray));
         CU_ASSERT_EQUAL( (int)resObj->paramCnt, cJSON_GetArraySize(paramArray) );
         
         result = (char *) malloc(sizeof(char) * MAX_PARAMETER_LEN);
@@ -822,21 +822,21 @@ void verify_testandset_response(cJSON *response, res_struct *resObj)
         for (i = 0; i < resObj->paramCnt; i++) 
 	{
 		resParamObj = cJSON_GetArrayItem(paramArray, i);
-		WdmpPrint("WDMP-C: Name[%zu] : %s\n", i,cJSON_GetObjectItem(resParamObj, "name")->valuestring );
+		WdmpPrint("Name[%zu] : %s\n", i,cJSON_GetObjectItem(resParamObj, "name")->valuestring );
 		if(0 == strcmp(cJSON_GetObjectItem(resParamObj, "name")->valuestring, WDMP_SYNC_PARAM_CID))
 		{
-		        WdmpPrint("WDMP-C: CID: %s\n", cJSON_GetObjectItem(resParamObj, "value")->valuestring);
+		        WdmpPrint("CID: %s\n", cJSON_GetObjectItem(resParamObj, "value")->valuestring);
                         CU_ASSERT_STRING_EQUAL( resObj->u.paramRes->syncCID, cJSON_GetObjectItem(resParamObj, "value")->valuestring );
                 }
                 else if(0 == strcmp(cJSON_GetObjectItem(resParamObj, "name")->valuestring, WDMP_SYNC_PARAM_CMC))
                 {
-                        WdmpPrint("WDMP-C: CMC: %d\n", cJSON_GetObjectItem(resParamObj, "value")->valueint);
+                        WdmpPrint("CMC: %d\n", cJSON_GetObjectItem(resParamObj, "value")->valueint);
                         CU_ASSERT_EQUAL( atoi(resObj->u.paramRes->syncCMC), cJSON_GetObjectItem(resParamObj, "value")->valueint );
                 }
                 
 	}
 	
-	WdmpInfo("WDMP-C: Message : %s\n",cJSON_GetObjectItem(response, "message")->valuestring);
+	WdmpInfo("Message : %s\n",cJSON_GetObjectItem(response, "message")->valuestring);
 	mapWdmpStatusToStatusMessage(resObj->retStatus[0], result);
         CU_ASSERT_STRING_EQUAL(result, cJSON_GetObjectItem(response, "message")->valuestring);
         
@@ -851,14 +851,14 @@ void verify_table_response(cJSON *response, res_struct *resObj)
         WDMP_RESPONSE_STATUS_CODE statusCode;
         char *result = NULL;
         
-        WdmpInfo("WDMP-C: Status code: %d\n", cJSON_GetObjectItem(response, "statusCode")->valueint);
+        WdmpInfo("Status code: %d\n", cJSON_GetObjectItem(response, "statusCode")->valueint);
         
         result = (char *) malloc(sizeof(char) * MAX_PARAMETER_LEN);
         
         if(resObj->reqType == ADD_ROWS)
         {
                 CU_ASSERT_EQUAL(WDMP_ADDROW_STATUS_SUCCESS, cJSON_GetObjectItem(response, "statusCode")->valueint);
-                WdmpPrint("WDMP-C: New row: %s\n", cJSON_GetObjectItem(response, "row")->valuestring);
+                WdmpPrint("New row: %s\n", cJSON_GetObjectItem(response, "row")->valuestring);
                 CU_ASSERT_STRING_EQUAL(resObj->u.tableRes->newObj, cJSON_GetObjectItem(response, "row")->valuestring);
         }
         else
@@ -867,7 +867,7 @@ void verify_table_response(cJSON *response, res_struct *resObj)
                 CU_ASSERT_EQUAL((int)statusCode, cJSON_GetObjectItem(response, "statusCode")->valueint);
         }
         
-        WdmpInfo("WDMP-C: Message : %s\n",cJSON_GetObjectItem(response, "message")->valuestring);
+        WdmpInfo("Message : %s\n",cJSON_GetObjectItem(response, "message")->valuestring);
         mapWdmpStatusToStatusMessage(resObj->retStatus[0], result);
         CU_ASSERT_STRING_EQUAL(result, cJSON_GetObjectItem(response, "message")->valuestring);
 }
@@ -877,13 +877,13 @@ void verify_failure_response(cJSON *response, res_struct *resObj)
         WDMP_RESPONSE_STATUS_CODE statusCode;
         char *result = NULL;
         
-        WdmpInfo("WDMP-C: Status code: %d\n", cJSON_GetObjectItem(response, "statusCode")->valueint);
+        WdmpInfo("Status code: %d\n", cJSON_GetObjectItem(response, "statusCode")->valueint);
         getStatusCode(&statusCode, 1, resObj->retStatus);
         CU_ASSERT_EQUAL((int)statusCode, cJSON_GetObjectItem(response, "statusCode")->valueint);
         
         result = (char *) malloc(sizeof(char) * MAX_PARAMETER_LEN);
         
-        WdmpInfo("WDMP-C: Message : %s\n",cJSON_GetObjectItem(response, "message")->valuestring);
+        WdmpInfo("Message : %s\n",cJSON_GetObjectItem(response, "message")->valuestring);
         mapWdmpStatusToStatusMessage(resObj->retStatus[0], result);
         CU_ASSERT_STRING_EQUAL(result, cJSON_GetObjectItem(response, "message")->valuestring);
 }
@@ -892,7 +892,7 @@ void get_res_form()
 {
         res_struct *resObj = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         cJSON *response = cJSON_CreateObject();
         
@@ -946,7 +946,7 @@ void get_res_form()
 	
 	verify_get_reponse(response, resObj);
 	
-        WdmpInfo("WDMP-C: Response Payload :\n%s\n",cJSON_Print(response));
+        WdmpInfo("Response Payload :\n%s\n",cJSON_Print(response));
         
         if(NULL != resObj)
         {
@@ -965,7 +965,7 @@ void get_wildcard_res_form()
         char *payload = NULL;
         cJSON * response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1033,7 +1033,7 @@ void get_wildcard_res_form()
         
         verify_get_reponse(response, resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1051,7 +1051,7 @@ void get_attr_res_form()
         res_struct *resObj = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         response = cJSON_CreateObject();
         resObj = (res_struct *) malloc(sizeof(res_struct));
@@ -1090,7 +1090,7 @@ void get_attr_res_form()
         
         verify_param_response(response,resObj);
         
-        WdmpInfo("WDMP-C: Response Payload :\n%s\n",cJSON_Print(response));
+        WdmpInfo("Response Payload :\n%s\n",cJSON_Print(response));
         
         if(NULL != resObj)
         {
@@ -1108,7 +1108,7 @@ void set_res_form()
         res_struct *resObj = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         response = cJSON_CreateObject();
         
@@ -1141,7 +1141,7 @@ void set_res_form()
         
         verify_param_response(response,resObj);
         
-        WdmpInfo("WDMP-C: Response Payload :\n%s\n",cJSON_Print(response));
+        WdmpInfo("Response Payload :\n%s\n",cJSON_Print(response));
         
         if(NULL != resObj)
         {
@@ -1159,7 +1159,7 @@ void set_attr_res_form()
         res_struct *resObj = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         response = cJSON_CreateObject();
         resObj = (res_struct *) malloc(sizeof(res_struct));
@@ -1191,7 +1191,7 @@ void set_attr_res_form()
         
         verify_param_response(response,resObj);
         
-        WdmpInfo("WDMP-C: Response Payload :\n%s\n",cJSON_Print(response));
+        WdmpInfo("Response Payload :\n%s\n",cJSON_Print(response));
         
         if(NULL != resObj)
         {
@@ -1209,7 +1209,7 @@ void test_and_set_res_form()
         res_struct *resObj = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         response = cJSON_CreateObject();
         
@@ -1239,7 +1239,7 @@ void test_and_set_res_form()
         
         verify_testandset_response(response,resObj);
 
-        WdmpInfo("WDMP-C: Response Payload :\n%s\n",cJSON_Print(response));
+        WdmpInfo("Response Payload :\n%s\n",cJSON_Print(response));
         
         if(NULL != resObj)
         {
@@ -1258,7 +1258,7 @@ void add_rows_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1283,7 +1283,7 @@ void add_rows_res_form()
         
         verify_table_response(response,resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1302,7 +1302,7 @@ void replace_rows_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1324,7 +1324,7 @@ void replace_rows_res_form()
         
         verify_table_response(response,resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1344,7 +1344,7 @@ void delete_row_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1366,7 +1366,7 @@ void delete_row_res_form()
         
         verify_table_response(response,resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1385,7 +1385,7 @@ void table_res_form()
         res_struct *resObj = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         response = cJSON_CreateObject();
         
@@ -1409,7 +1409,7 @@ void table_res_form()
         
         verify_table_response(response,resObj);
         
-        WdmpInfo("WDMP-C: Response Payload :\n%s\n",cJSON_Print(response));
+        WdmpInfo("Response Payload :\n%s\n",cJSON_Print(response));
         
         if(NULL != resObj)
         {
@@ -1429,7 +1429,7 @@ void test_get_status_code()
         WDMP_STATUS * ret = NULL;
         int paramCount = 3;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         ret = (WDMP_STATUS *) malloc(sizeof(WDMP_STATUS)*paramCount);
         
@@ -1441,7 +1441,7 @@ void test_get_status_code()
         
         CU_ASSERT_EQUAL( WDMP_STATUS_WIFI_BUSY, statusCode );
         
-        WdmpInfo("WDMP-C: statusCode : %d\n",statusCode);
+        WdmpInfo("statusCode : %d\n",statusCode);
         
         if(ret)
         {
@@ -1454,7 +1454,7 @@ void test_map_wdmp_status()
         WDMP_STATUS status;
         char *result = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         result = (char *) malloc(sizeof(char)*MAX_PARAMETER_LEN);
         status = WDMP_ERR_SET_OF_CMC_OR_CID_NOT_SUPPORTED;
@@ -1465,7 +1465,7 @@ void test_map_wdmp_status()
         
         CU_ASSERT_STRING_EQUAL( "SET of CMC or CID is not supported", result );
         
-        WdmpInfo("WDMP-C: result : %s\n",result);
+        WdmpInfo("result : %s\n",result);
         
         if(result)
         {
@@ -1479,7 +1479,7 @@ void neg_get_res_form()
         char *payload = NULL;
         cJSON * response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1513,7 +1513,7 @@ void neg_get_res_form()
         
         verify_failure_response(response, resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1532,7 +1532,7 @@ void get_wildcard_empty_value_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1579,7 +1579,7 @@ void get_wildcard_empty_value_res_form()
         
         verify_get_reponse(response, resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1598,7 +1598,7 @@ void neg_get_attr_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1625,7 +1625,7 @@ void neg_get_attr_res_form()
         
         verify_failure_response(response, resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1644,7 +1644,7 @@ void neg_set_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1671,7 +1671,7 @@ void neg_set_res_form()
         
         verify_failure_response(response, resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1690,7 +1690,7 @@ void neg_set_attr_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1726,7 +1726,7 @@ void neg_set_attr_res_form()
         
         verify_param_response(response, resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1745,7 +1745,7 @@ void neg_test_and_set_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1777,7 +1777,7 @@ void neg_test_and_set_res_form()
         
         verify_testandset_response(response, resObj);
         
-        WdmpInfo("WDMP-C: Payload :%s\n",payload);
+        WdmpInfo("Payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1796,7 +1796,7 @@ void test_cmc()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1827,7 +1827,7 @@ void test_cmc()
         
         verify_failure_response(response, resObj);
         
-        WdmpInfo("WDMP-C: Payload :%s\n",payload);
+        WdmpInfo("Payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1847,7 +1847,7 @@ void test_and_set_without_cid_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1878,7 +1878,7 @@ void test_and_set_without_cid_res_form()
         
         verify_failure_response(response, resObj);
         
-        WdmpInfo("WDMP-C: Payload :%s\n",payload);
+        WdmpInfo("Payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1897,7 +1897,7 @@ void neg_add_rows_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1919,7 +1919,7 @@ void neg_add_rows_res_form()
         
         verify_failure_response(response,resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1938,7 +1938,7 @@ void neg_replace_rows_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -1960,7 +1960,7 @@ void neg_replace_rows_res_form()
         
         verify_failure_response(response,resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -1980,7 +1980,7 @@ void neg_delete_row_res_form()
         char *payload = NULL;
         cJSON *response = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));
@@ -2002,7 +2002,7 @@ void neg_delete_row_res_form()
         
         verify_failure_response(response,resObj);
         
-        WdmpInfo("WDMP-C: payload :%s\n",payload);
+        WdmpInfo("payload :%s\n",payload);
         
         if(NULL != resObj)
         {
@@ -2021,7 +2021,7 @@ void test_unknown_req_type()
         res_struct *resObj = NULL;
         char *payload = NULL;
         
-        WdmpInfo("WDMP-C: \n***************************************************** \n\n");
+        WdmpInfo("\n***************************************************** \n\n");
         
         resObj = (res_struct *) malloc(sizeof(res_struct));
         memset(resObj, 0, sizeof(res_struct));


### PR DESCRIPTION
wdmp-c can use cimplogger for logging. This option is configurable using macro 'CIMP_LOGGER'