### PR TITLE
Update wdmp_internal.c

### DIFF
--- a/src/wdmp_internal.c
+++ b/src/wdmp_internal.c
@@ -63,8 +63,7 @@ void parse_get_request(cJSON *request, req_struct **reqObj)
 	
 	for (i = 0; i < paramCount; i++) 
 	{
-		(*reqObj)->u.getReq->paramNames[i] = (char *) malloc(sizeof(char)*MAX_PARAMETER_LEN);
-		strcpy((*reqObj)->u.getReq->paramNames[i], cJSON_GetArrayItem(paramArray, i)->valuestring);
+		(*reqObj)->u.getReq->paramNames[i] = strndup((cJSON_GetArrayItem(paramArray, i)->valuestring), sizeof(char)*MAX_PARAMETER_LEN);
 		WdmpPrint("(*reqObj)->u.getReq->paramNames[%zu] : %s\n",i,(*reqObj)->u.getReq->paramNames[i]);
 	}
 


### PR DESCRIPTION
Instead of malloc() for MAX_PARAMETER_LEN, we can malloc just enough space required for params (using strdup()/or malloc(strlen+1)), since most params sizes are much less than MAX_PARAMETER_LEN.