### PR TITLE
Add message field to payload during Invalid WebPA Parameter query

### DIFF
--- a/src/wdmp_internal.c
+++ b/src/wdmp_internal.c
@@ -456,6 +456,8 @@ void wdmp_form_get_response(res_struct *resObj, cJSON *response)
                                 cJSON_AddStringToObject(resParamObj, "name", resObj->u.getRes->paramNames[i]);
                                 cJSON_AddStringToObject(resParamObj, "value","EMPTY");
                                 cJSON_AddNumberToObject(resParamObj, "parameterCount", resObj->u.getRes->retParamCnt[i]);
+				mapWdmpStatusToStatusMessage(resObj->retStatus[i], result);
+	                        cJSON_AddStringToObject(resParamObj, "message", result);
                         }
                 }
         }


### PR DESCRIPTION
Incorrect JSON message in Invalid WebPA Parameter case
Adding the message field to Result JSON in failure case
Test Procedure: Do a WebPa GET queries of multiple combinations with invalid parameters
